### PR TITLE
osg.performance.now fallback of performance.now

### DIFF
--- a/js/osgViewer/Viewer.js
+++ b/js/osgViewer/Viewer.js
@@ -443,7 +443,7 @@ osgViewer.Viewer.prototype = osg.objectInehrit(osgViewer.View.prototype, {
 
     frame: function() {
         var frameTime, beginFrameTime;
-        frameTime = performance.now();
+        frameTime = osg.performance.now();
         if (this._lastFrameTime === undefined) {
             this._lastFrameTime = 0;
         }
@@ -488,26 +488,26 @@ osgViewer.Viewer.prototype = osg.objectInehrit(osgViewer.View.prototype, {
             this.draw();
             frameStamp.setFrameNumber(frameStamp.getFrameNumber()+1);
             this._numberFrame++;
-            this._frameTime = performance.now() - beginFrameTime;
+            this._frameTime = osg.performance.now() - beginFrameTime;
         }
         else{
-            this._updateTime = performance.now();
+            this._updateTime = osg.performance.now();
             this.update();
-            this._updateTime =  performance.now() - this._updateTime;
+            this._updateTime =  osg.performance.now() - this._updateTime;
 
 
-            this._cullTime =  performance.now();
+            this._cullTime =  osg.performance.now();
             this.cull();
-            this._cullTime = performance.now() - this._cullTime;
+            this._cullTime = osg.performance.now() - this._cullTime;
 
-            this._drawTime =  performance.now();
+            this._drawTime =  osg.performance.now();
             this.draw();
-            this._drawTime = performance.now() - this._drawTime;
+            this._drawTime = osg.performance.now() - this._drawTime;
 
             frameStamp.setFrameNumber(frameStamp.getFrameNumber()+1);
 
             this._numberFrame++;
-            this._frameTime = performance.now() - beginFrameTime;
+            this._frameTime = osg.performance.now() - beginFrameTime;
 
             if ( window.performance && window.performance.memory && window.performance.memory.usedJSHeapSize)
                 this._memSize = window.performance.memory.usedJSHeapSize;

--- a/js/osgViewer/stats.js
+++ b/js/osgViewer/stats.js
@@ -45,7 +45,7 @@ Stats.Stats.prototype = {
 
     update: function() {
 
-        var delta, i, l, layer, value, c, ctx, height, myImageData, t = performance.now();
+        var delta, i, l, layer, value, c, ctx, height, myImageData, t = osg.performance.now();
         if(this.last_update === undefined) {
             this.last_update = t;
         }

--- a/js/osgViewer/webgl-utils.js
+++ b/js/osgViewer/webgl-utils.js
@@ -198,11 +198,14 @@ if(!Date.now) {
 }
 
 
-window.performance = window.performance || {};
-performance.now = (function() {
-    return window.performance.now || window.performance.mozNow || window.performance.msNow || window.performance.oNow || window.performance.webkitNow ||
+osg.performance = {};
+osg.performance.now = (function() {
+    var fn = window.performance.now || window.performance.mozNow || window.performance.msNow || window.performance.oNow || window.performance.webkitNow ||
     function() {
         return Date.now();
+    };
+    return function() {
+        return fn.apply(window.performance, arguments);
     };
 })();
 


### PR DESCRIPTION
Firefox 10's performance object isn't stable and is regularly reset.
An object osg.performance has been created, containing a osg.performance.now function which a bind to performance.now if present, and fallback to Date.now() if not.
osg.performance.now should be used in place of performance.now.
