### PR TITLE
Abstracts console logging

### DIFF
--- a/sources/osg/Notify.js
+++ b/sources/osg/Notify.js
@@ -8,12 +8,14 @@ define( [], function () {
     Notify.WARN = 3;
     Notify.ERROR = 4;
 
+    Notify.console = window.console;
+
     // #FIXME getStackTrace was initially in webgl-utils (as a global function) but only used in this file
     /** Obtain a stacktrace from the current stack http://eriwen.com/javascript/js-stack-trace/
      */
     function getStackTrace( err ) {
-		if (window.console && window.console.trace){
-			window.console.trace();
+		if (Notify.console && Notify.console.trace){
+			Notify.console.trace();
 			return '';
         }
         var callstack = [];
@@ -48,32 +50,32 @@ define( [], function () {
     Notify.setNotifyLevel = function ( level ) {
 
         var log = function ( str ) {
-            if ( window.console !== undefined ) {
-                window.console.log( str, getStackTrace() );
+            if ( this.console !== undefined ) {
+                this.console.log( str, getStackTrace() );
             }
         };
 
         var info = function ( str ) {
-            if ( window.console !== undefined ) {
-                window.console.info( str, getStackTrace() );
+            if ( this.console !== undefined ) {
+                this.console.info( str, getStackTrace() );
             }
         };
 
         var warn = function ( str ) {
-            if ( window.console !== undefined ) {
-                window.console.warn( str, getStackTrace() );
+            if ( this.console !== undefined ) {
+                this.console.warn( str, getStackTrace() );
             }
         };
 
         var error = function ( str ) {
-            if ( window.console !== undefined ) {
-                window.console.error( str, getStackTrace() );
+            if ( this.console !== undefined ) {
+                this.console.error( str, getStackTrace() );
             }
         };
 
         var debug = function ( str ) {
-            if ( window.console !== undefined ) {
-                window.console.debug( str, getStackTrace() );
+            if ( this.console !== undefined ) {
+                this.console.debug( str, getStackTrace() );
             }
         };
 
@@ -105,6 +107,10 @@ define( [], function () {
     Notify.setNotifyLevel( Notify.NOTICE );
 
     Notify.reportWebGLError = false;
+
+    Notify.setConsole = function( replacement ) {
+        Notify.console = replacement;
+    };
 
     return Notify;
 } );

--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -122,7 +122,7 @@ define( [
     } ), 'osg', 'Program' );
 
     Program.create = function ( vShader, fShader ) {
-        console.log( 'Program.create is deprecated use new Program(vertex, fragment) instead' );
+        Notify.log( 'Program.create is deprecated use new Program(vertex, fragment) instead' );
         var program = new Program( vShader, fShader );
         return program;
     };

--- a/sources/osg/Utils.js
+++ b/sources/osg/Utils.js
@@ -180,70 +180,59 @@ define( [
         };
     } )();
 
-    Utils.timeStamp = ( function () {
+    Utils.timeStamp = function () {
 
-        var fn = console.timeStamp || console.markTimeline || function () {};
-        return function () {
-            return fn.apply( console, arguments );
+        var fn = Notify.console.timeStamp || Notify.console.markTimeline || function () {};
+        return fn.apply( Notify.console, arguments );
+
+    };
+
+    var times = {};
+
+    Utils.time = function () {
+
+        var fn = Notify.console.time || function ( name ) {
+            times[ name ] = Utils.performance.now();
         };
+        return fn.apply( Notify.console, arguments );
 
-    } )();
+    };
 
-    ( function () {
+    Utils.timeEnd = function () {
 
-        var times = {};
+        var fn = Notify.console.timeEnd || function ( name ) {
 
-        Utils.time = ( function () {
+            if ( times[ name ] === undefined )
+                return;
 
-            var fn = console.time || function ( name ) {
-                times[ name ] = Utils.performance.now();
-            };
-            return function ( /*name*/ ) {
-                return fn.apply( console, arguments );
-            };
+            var now = Utils.performance.now();
+            var duration = now - times[ name ];
 
-        } )();
+            Notify.debug( name + ': ' + duration + 'ms');
+            times[ name ] = undefined;
 
-        Utils.timeEnd = ( function () {
+        };
+        return fn.apply( Notify.console, arguments );
 
-            var fn = console.timeEnd || function ( name ) {
-
-                if ( times[ name ] === undefined )
-                    return;
-
-                var now = Utils.performance.now();
-                var duration = now - times[ name ];
-
-                Notify.debug( name + ': ' + duration + 'ms');
-                times[ name ] = undefined;
-
-            };
-            return function () {
-                return fn.apply( console, arguments );
-            };
-
-        } )();
-
-    } )();
+    };
 
     Utils.profile = ( function () {
 
-        var fn = console.profile || function () {};
+        var fn = Notify.console.profile || function () {};
         return function () {
-            return fn.apply( console, arguments );
+            return fn.apply( Notify.console, arguments );
         };
 
     } )();
 
     Utils.profileEnd = ( function () {
 
-        var fn = console.profileEnd || function () {};
+        var fn = Notify.console.profileEnd || function () {};
         return function () {
-            return fn.apply( console, arguments );
+            return fn.apply( Notify.console, arguments );
         };
 
     } )();
-
 
     return Utils;
 } );

--- a/sources/osgGA/OrbitManipulatorGamePadController.js
+++ b/sources/osgGA/OrbitManipulatorGamePadController.js
@@ -53,7 +53,7 @@ define( [], function () {
 
                 //SpaceNavigator & 6-axis controllers
             } else if ( axes.length >= 5 ) {
-                //console.log(axes);
+                //Notify.log(axes);
                 if ( Math.abs( axes[ 0 ] ) > AXIS_THRESHOLD || Math.abs( axes[ 1 ] ) > AXIS_THRESHOLD ) {
                     this.addPan( pan, -axes[ 0 ], axes[ 1 ] );
                 }

--- a/sources/osgUtil/Composer.js
+++ b/sources/osgUtil/Composer.js
@@ -335,7 +335,7 @@ define( [
                             row[ i ] = row[ i ] / sum;
                             //str += row[i].toString() + ' ';
                         }
-                        //console.log(str);
+                        //Notify.log(str);
                     }
                 } )();
 

--- a/sources/osgViewer/webgl-debug.js
+++ b/sources/osgViewer/webgl-debug.js
@@ -1,6 +1,10 @@
 /* jshint ignore:start */
 
-define( [], function () {
+define( [
+
+    'osg/Notify'
+
+], function ( Notify ) {
 
     //Copyright (c) 2009 The Chromium Authors. All rights reserved.
     //Use of this source code is governed by a BSD-style license that can be
@@ -9,16 +13,6 @@ define( [], function () {
     // Various functions for helping debug WebGL apps.
 
     var WebGLDebugUtils = function () {
-
-        /**
-         * Wrapped logging function.
-         * @param {string} msg Message to log.
-         */
-        var log = function ( msg ) {
-            if ( window.console && window.console.log ) {
-                window.console.log( msg );
-            }
-        };
 
         /**
          * Which arguements are enums.
@@ -306,24 +300,24 @@ define( [], function () {
         }
 
         function makePropertyWrapper( wrapper, original, propertyName ) {
-            //log("wrap prop: " + propertyName);
+            //Notify.log("wrap prop: " + propertyName);
             wrapper.__defineGetter__( propertyName, function () {
                 return original[ propertyName ];
             } );
             // TODO(gmane): this needs to handle properties that take more than
             // one value?
             wrapper.__defineSetter__( propertyName, function ( value ) {
-                //log("set: " + propertyName);
+                //Notify.log("set: " + propertyName);
                 original[ propertyName ] = value;
             } );
         }
 
         // Makes a function that calls a function on another object.
         function makeFunctionWrapper( original, functionName ) {
-            //log("wrap fn: " + functionName);
+            //Notify.log("wrap fn: " + functionName);
             var f = original[ functionName ];
             return function () {
-                //log("call: " + functionName);
+                //Notify.log("call: " + functionName);
                 var result = f.apply( original, arguments );
                 return result;
             };
@@ -339,7 +333,7 @@ define( [], function () {
          * @param {!function(err, funcName, args): void} opt_onErrorFunc
          *        The function to call when gl.getError returns an
          *        error. If not specified the default function calls
-         *        console.log with a message.
+         *        Notify.log with a message.
          */
         function makeDebugContext( ctx, opt_onErrorFunc ) {
             init( ctx );
@@ -350,7 +344,7 @@ define( [], function () {
                     argStr += ( ( ii === 0 ) ? '' : ', ' ) +
                         glFunctionArgToString( functionName, ii, args[ ii ] );
                 }
-                log( "WebGL error " + glEnumToString( err ) + " in " + functionName +
+                Notify.log( "WebGL error " + glEnumToString( err ) + " in " + functionName +
                     "(" + argStr + ")" );
             };
 
@@ -545,9 +539,9 @@ define( [], function () {
                     var event = makeWebGLContextEvent( "context lost" );
                     var callbacks = onLost_.slice();
                     setTimeout( function () {
-                        //log("numCallbacks:" + callbacks.length);
+                        //Notify.log("numCallbacks:" + callbacks.length);
                         for ( var ii = 0; ii < callbacks.length; ++ii ) {
-                            //log("calling callback:" + ii);
+                            //Notify.log("calling callback:" + ii);
                             callbacks[ ii ]( event );
                         }
                         if ( restoreTimeout_ >= 0 ) {
@@ -636,7 +630,7 @@ define( [], function () {
             function makeLostContextFunctionWrapper( ctx, functionName ) {
                 var f = ctx[ functionName ];
                 return function () {
-                    // log("calling:" + functionName);
+                    // Notify.log("calling:" + functionName);
                     // Only call the functions if the context is not lost.
                     loseContextIfTime();
                     if ( !contextLost_ ) {
@@ -893,7 +887,7 @@ define( [], function () {
              * @param {!WebGLRenderingContext} ctx The webgl context to wrap.
              * @param {!function(err, funcName, args): void} opt_onErrorFunc The function
              *     to call when gl.getError returns an error. If not specified the default
-             *     function calls console.log with a message.
+             *     function calls Notify.log with a message.
              */
             'makeDebugContext': makeDebugContext,
 


### PR DESCRIPTION
No more direct call to console.log is done.
It is now possible to override the log destination, by calling osg.setConsole.
