### PR TITLE
Fix import node

### DIFF
--- a/sources/osgWrappers/serializers/osg.js
+++ b/sources/osgWrappers/serializers/osg.js
@@ -26,7 +26,7 @@ define( [
 
         return obj;
     };
-
+    /* jshint newcap: false */
     osgWrapper.Node = function ( input, node ) {
         var jsonObj = input.getJSON();
 


### PR DESCRIPTION
Fixed bad ordering when adding childs from osgjs files. Now it loads in the same ordering that are defined in the osgjs file. Before it was adding  childs depending on the time to load of each child. I can provide a test.osgjs file. 
