### PR TITLE
Fixed bug in getFrustumPlanes:far plane calculation was assigning wrong ...

### DIFF
--- a/sources/osg/CullVisitor.js
+++ b/sources/osg/CullVisitor.js
@@ -462,7 +462,8 @@ define( [
 
     CullVisitor.prototype[ Node.typeID ] = function ( node ) {
 
-        if ( this._enableFrustumCulling === true && node.isCullingActive() && this.isCulled ( node ) ) return;
+        // We need the frame stamp > 0 to do the frustum culling, otherwise the projection matrix is not correct
+        if ( this._enableFrustumCulling === true && node.isCullingActive() && this.getFrameStamp().getFrameNumber() !== 0 && this.isCulled ( node ) ) return;
 
         var stateset = node.getStateSet();
         if ( stateset ) {

--- a/sources/osg/Matrix.js
+++ b/sources/osg/Matrix.js
@@ -1101,7 +1101,7 @@ define( [
                 far[ 0 ] = matrix[ 3 ] - matrix[ 2 ];
                 far[ 1 ] = matrix[ 7 ] - matrix[ 6 ];
                 far[ 2 ] = matrix[ 11 ] - matrix[ 10 ];
-                far[ 2 ] = matrix[ 15 ] - matrix[ 14 ];
+                far[ 3 ] = matrix[ 15 ] - matrix[ 14 ];
                 result[ 4 ] = far;
                 // Near clipping plane.
                 near[ 0 ] = matrix[ 3 ] + matrix[ 2 ];


### PR DESCRIPTION
...the distance value. Also disable culling when the current frameNumber is 0
