### PR TITLE
On Mac (FF+Chromium), we must invert the Left and Right angles of both eyes

### DIFF
--- a/sources/osgUtil/WebVR.js
+++ b/sources/osgUtil/WebVR.js
@@ -215,6 +215,23 @@ define( [
         if ( hmdDevice.getRecommendedRenderTargetSize )
             hmd.rttResolution = hmdDevice.getRecommendedRenderTargetSize();
 
+        // On Mac (FF+Chromium), the Left and Right angles of both eyes are inverted
+        // Left Eye must see more to the Left than to the Right (Left angle > Right angle)
+        // Right Eye must see more to the Right than to the Left (Right angle > Left angle)
+        // This is because of the nose blocking the view
+        var swapLeftAndRight = function ( fov ) {
+            var temp = fov.leftDegrees;
+            fov.leftDegrees = fov.rightDegrees;
+            fov.rightDegrees = temp;
+        };
+
+        if ( hmd.fovLeft.leftDegrees < hmd.fovLeft.rightDegrees ) {
+            swapLeftAndRight( hmd.fovLeft );
+        }
+        if ( hmd.fovRight.rightDegrees < hmd.fovRight.leftDegrees ) {
+            swapLeftAndRight( hmd.fovRight );
+        }
+        
         return hmd;
     }
 


### PR DESCRIPTION
Left Eye must see more to the Left than to the Right (Left angle > Right angle)
Right Eye must see more to the Right than to the Left (Right angle > Left angle)
This is because of the nose blocking the view
We are not totally sure the angles are right (they differ on windows) but at least inverting them fixes the vr experience .
