### PR TITLE
fix text.js noderequire not being overridable outside of bundle

### DIFF
--- a/sources/vendors/require/Text-2.0.12.js
+++ b/sources/vendors/require/Text-2.0.12.js
@@ -246,7 +246,8 @@ define(['module'], function (module) {
             !!process.versions.node &&
             !process.versions['node-webkit'])) {
         //Using special require.nodeRequire, something added by r.js.
-        fs = require.nodeRequire('fs');
+        var requireRef = global.require || require;
+        fs = requireRef.nodeRequire('fs');
 
         text.get = function (url, callback, errback) {
             try {


### PR DESCRIPTION
fix text.js noderequire not being overridable outside of bundle
