### PR TITLE
Adds failSafe shader that will work every where whenever a shader fails ...

### DIFF
--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -53,25 +53,39 @@ define( [
                 if ( this.defaultProgram === true ) {
                     return;
                 }
-
+                var compileClean;
                 if ( !this.vertex.shader ) {
-                    this.vertex.compile( gl );
+                    compileClean = this.vertex.compile( gl );
                 }
                 if ( !this.fragment.shader ) {
-                    this.fragment.compile( gl );
+                    compileClean = this.fragment.compile( gl );
                 }
-                this.program = gl.createProgram();
-                gl.attachShader( this.program, this.vertex.shader );
-                gl.attachShader( this.program, this.fragment.shader );
-                MACROUTILS.timeStamp( 'osgjs.metrics:linkShader' );
-                gl.linkProgram( this.program );
-                gl.validateProgram( this.program );
-                if ( !gl.getProgramParameter( this.program, gl.LINK_STATUS ) && !gl.isContextLost() ) {
-                    Notify.error( gl.getProgramInfoLog( this.program ) );
-                    Notify.log( 'can\'t link program\n' + 'vertex shader:\n' + this.vertex.text + '\n fragment shader:\n' + this.fragment.text, true );
-                    this.setDirty( false );
-                    //debugger;
-                    return;
+                if ( compileClean ) {
+                    this.program = gl.createProgram();
+                    gl.attachShader( this.program, this.vertex.shader );
+                    gl.attachShader( this.program, this.fragment.shader );
+                    MACROUTILS.timeStamp( 'osgjs.metrics:linkShader' );
+                    gl.linkProgram( this.program );
+                    gl.validateProgram( this.program );
+                    if ( !gl.getProgramParameter( this.program, gl.LINK_STATUS ) && !gl.isContextLost() ) {
+                        Notify.error( gl.getProgramInfoLog( this.program ) );
+                        Notify.log( 'can\'t link program\n' + 'vertex shader:\n' + this.vertex.text + '\n fragment shader:\n' + this.fragment.text, true );
+                        compileClean = false;
+                        //debugger;
+                    }
+                }
+                if ( !compileClean ) {
+                    // Any error, Any
+                    // Pink must die.
+                    this.vertex.failSafe( gl );
+                    this.fragment.failSafe( gl );
+                    this.program = gl.createProgram();
+                    gl.attachShader( this.program, this.vertex.shader );
+                    gl.attachShader( this.program, this.fragment.shader );
+                    gl.linkProgram( this.program );
+                    gl.validateProgram( this.program );
+                    Notify.warn( 'FailSafe shader Activated ' );
+
                 }
 
                 this.uniformsCache = new Map();

--- a/sources/osg/Shader.js
+++ b/sources/osg/Shader.js
@@ -20,6 +20,10 @@ define( [
     Shader.VERTEX_SHADER = 0x8B31;
     Shader.FRAGMENT_SHADER = 0x8B30;
 
+    // Debug Pink shader for when shader fails
+    Shader.VS_DBG = 'attribute vec3 Vertex;uniform mat4 ModelViewMatrix;uniform mat4 ProjectionMatrix;void main(void) {  gl_Position = ProjectionMatrix * ModelViewMatrix * vec4(Vertex, 1.0);}';
+    Shader.FS_DBG = 'precision lowp float; void main(void) { gl_FragColor = vec4(1.0, 0.6, 0.6, 1.0);}';
+
     /** @lends Shader.prototype */
     Shader.prototype = {
         setText: function( text ) {
@@ -27,6 +31,12 @@ define( [
         },
         getText: function() {
             return this.text;
+        },
+        // this is where it creates a fail safe shader that should work everywhere
+        failSafe: function ( gl ) {
+            this.shader = gl.createShader( this.type );
+            gl.shaderSource( this.shader, this.type === Shader.VERTEX_SHADER ? Shader.VS_DBG : Shader.FS_DBG );
+            gl.compileShader( this.shader );
         },
         compile: function( gl ) {
             this.shader = gl.createShader( this.type );
@@ -42,7 +52,10 @@ define( [
                     newText += i + ' ' + splittedText[ i ] + '\n';
                 }
                 Notify.log( 'can\'t compile shader:\n' + newText, true );
+
+                return false;
             }
+            return true;
         }
     };
 

--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -452,11 +452,11 @@ define( [
 
         // return the first texture valid in texture unit
         getFirstValidTexture: function () {
-            var keys = Object.keys(this._texturesByName);
+            var keys = Object.keys( this._texturesByName );
             if ( !keys.length )
                 return undefined;
 
-            return this._texturesByName[ keys[0] ].variable;
+            return this._texturesByName[ keys[ 0 ] ].variable;
         },
 
 


### PR DESCRIPTION
...to compile, thus not looping forever on that shader error and cluttering the console and the devtools cpu usage.
Advanced User should be able to override Shader.VS_DBG and Shader.FS_DBG to other shader if need be. 
(in production, you'll avoid transforming vertex and output in negative depth)
