### PR TITLE
Adds Texture:setAnisotropy( filter multiplier)  method

### DIFF
--- a/examples/materials/main.js
+++ b/examples/materials/main.js
@@ -11,19 +11,19 @@
 
     // we use this visitor to copy TexCoord0 to TexCoord1
     // for multi texture purpose
-    var VisitorCopyTexCoord = function() {
-        osg.NodeVisitor.call(this);
+    var VisitorCopyTexCoord = function () {
+        osg.NodeVisitor.call( this );
     };
 
     VisitorCopyTexCoord.prototype = osg.objectInherit( osg.NodeVisitor.prototype, {
-        apply: function( node ) {
+        apply: function ( node ) {
             if ( node.getTypeID() === osg.Geometry.getTypeID() ) {
                 // copy tex coord 0 to 1 for multi texture
                 node.getAttributes()[ 'TexCoord1' ] = node.getAttributes()[ 'TexCoord0' ];
             }
             this.traverse( node );
         }
-    });
+    } );
 
 
 
@@ -42,6 +42,18 @@
             'alpha/basic.png'
         ];
 
+        this._textureMinFilters = [
+            'LINEAR',
+            'NEAREST',
+            'NEAREST_MIPMAP_NEAREST',
+            'LINEAR_MIPMAP_NEAREST',
+            'NEAREST_MIPMAP_LINEAR',
+            'LINEAR_MIPMAP_LINEAR'
+        ];
+        this._textureMagFilters = [
+            'LINEAR',
+            'NEAREST'
+        ];
 
         this._config = {
 
@@ -65,6 +77,9 @@
             materialShininess3: 0.4,
             texture3Unit0: this._textureNames[ 2 ],
             texture3Unit1: this._textureNames[ 1 ],
+            texture3UnitMinFilter: 'LINEAR_MIPMAP_LINEAR',
+            texture3UnitMagFilter: 'LINEAR',
+            texture3UnitAnisotropy: 1,
 
             materialEmission4: '#050505',
             materialAmbient4: '#050505',
@@ -220,6 +235,7 @@
                     texture.setWrapT( 'REPEAT' );
                     texture.setWrapS( 'REPEAT' );
                     texture.setMinFilter( 'LINEAR_MIPMAP_LINEAR' );
+                    texture.setMagFilter( 'LINEAR' );
                     return texture;
                 } );
 
@@ -242,7 +258,17 @@
 
                 controller = material3.add( this._config, 'texture3Unit1', this._textureNames );
                 controller.onChange( this.updateMaterial3.bind( this ) );
+
+                controller = material3.add( this._config, 'texture3UnitMinFilter', this._textureMinFilters );
+                controller.onChange( this.updateMaterial3.bind( this ) );
+                controller = material3.add( this._config, 'texture3UnitMagFilter', this._textureMagFilters );
+                controller.onChange( this.updateMaterial3.bind( this ) );
+                controller = material3.add( this._config, 'texture3UnitAnisotropy', 1, 16 ).step( 1 );
+                controller.onChange( this.updateMaterial3.bind( this ) );
+
                 this.updateMaterial3();
+
+
 
                 controller = material5.add( this._config, 'texture5Unit0', this._textureNames );
                 controller.onChange( this.updateMaterial5.bind( this ) );
@@ -400,13 +426,22 @@
             idx = this._textureNames.indexOf( this._config.texture3Unit0 );
             if ( idx < 0 ) idx = 0;
             texture = this._textures[ idx ];
+            texture.setMinFilter( this._config.texture3UnitMinFilter );
+            texture.setMagFilter( this._config.texture3UnitMagFilter );
+            texture.setMaxAnisotropy( this._config.texture3UnitAnisotropy );
+            //TODO: better dirty when setting dynamically a filter
+            texture.releaseGLObjects();
             this._stateSet3.setTextureAttributeAndModes( 0, texture );
 
             idx = this._textureNames.indexOf( this._config.texture3Unit1 );
             if ( idx < 0 ) idx = 3;
             texture = this._textures[ idx ];
+            texture.setMinFilter( this._config.texture3UnitMinFilter );
+            texture.setMagFilter( this._config.texture3UnitMagFilter );
+            texture.setMaxAnisotropy( this._config.texture3UnitAnisotropy );
+            //TODO: better dirty when setting dynamically a filter
+            texture.releaseGLObjects();
             this._stateSet3.setTextureAttributeAndModes( 1, texture );
-
 
         },
 

--- a/sources/osg/Texture.js
+++ b/sources/osg/Texture.js
@@ -58,6 +58,9 @@ define( [
     Texture.LINEAR_MIPMAP_NEAREST = 0x2701;
     Texture.NEAREST_MIPMAP_LINEAR = 0x2702;
     Texture.LINEAR_MIPMAP_LINEAR = 0x2703;
+    // filter anisotropy
+    Texture.TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE;
+    Texture.MAX_TEXTURE_MAX_ANISOTROPY_EXT = 0x84FF;
 
     // wrap mode
     Texture.CLAMP_TO_EDGE = 0x812F;
@@ -130,6 +133,7 @@ define( [
             this._image = undefined;
             this._magFilter = Texture.LINEAR;
             this._minFilter = Texture.LINEAR;
+            this._maxAnisotropy = 1.0;
             this._wrapS = Texture.CLAMP_TO_EDGE;
             this._wrapT = Texture.CLAMP_TO_EDGE;
             this._textureWidth = 0;
@@ -145,10 +149,10 @@ define( [
         },
 
         // check https://www.khronos.org/registry/webgl/specs/latest/1.0/#PIXEL_STORAGE_PARAMETERS
-        setColorSpaceConversion: function( enumValue ) {
+        setColorSpaceConversion: function ( enumValue ) {
             this._colorSpaceConversion = enumValue;
         },
-        setFlipY: function( bool ) {
+        setFlipY: function ( bool ) {
             this._flipY = bool;
         },
 
@@ -192,11 +196,12 @@ define( [
         getHeight: function () {
             return this._textureHeight;
         },
-        releaseGLObjects: function ( ) {
+        releaseGLObjects: function () {
             if ( this._textureObject !== undefined && this._textureObject !== null ) {
                 Texture.textureManager.releaseTextureObject( this._textureObject );
                 this._textureObject = undefined;
-                this._image = undefined;
+                if ( this._unrefImageDataAfterApply )
+                    this._image = undefined;
             }
         },
 
@@ -207,14 +212,6 @@ define( [
         getWrapS: function () {
             return this._wrapS;
         },
-        getMinFilter: function () {
-            return this._minFilter;
-        },
-        getMagFilter: function () {
-            return this._magFilter;
-        },
-
-
         setWrapS: function ( value ) {
 
             if ( typeof ( value ) === 'string' ) {
@@ -224,10 +221,8 @@ define( [
             } else {
 
                 this._wrapS = value;
-
             }
         },
-
 
         setWrapT: function ( value ) {
 
@@ -238,35 +233,51 @@ define( [
             } else {
 
                 this._wrapT = value;
-
             }
         },
 
+        getMinFilter: function () {
+            return this._minFilter;
+        },
+        getMagFilter: function () {
+            return this._magFilter;
+        },
 
+        // https://www.opengl.org/registry/specs/EXT/texture_filter_anisotropic.txt
+        setMaxAnisotropy: function ( multiplier ) {
+            var anisoExt = Texture.ANISOTROPIC_SUPPORT_EXT;
+            if ( anisoExt && multiplier && multiplier > 1.0 ) {
+                var max = Texture.ANISOTROPIC_SUPPORT_MAX;
+                multiplier = multiplier > max ? max : multiplier;
+                if ( multiplier !== this._maxAnisotropy ) {
+                    this._maxAnisotropy = multiplier;
+                    this.dirty();
+                }
+            }
+        },
+        getMaxAnisotropy: function () {
+            return this._maxAnisotropy;
+        },
+
+        // some value enable mipmapping
         setMinFilter: function ( value ) {
-
             if ( typeof ( value ) === 'string' ) {
-
                 this._minFilter = checkAndFixEnum( value, Texture.LINEAR );
-
             } else {
-
                 this._minFilter = value;
-
             }
+            this.dirty();
         },
 
+        // Either Linear or nearest.
         setMagFilter: function ( value ) {
 
             if ( typeof ( value ) === 'string' ) {
-
                 this._magFilter = checkAndFixEnum( value, Texture.LINEAR );
-
             } else {
-
                 this._magFilter = value;
-
             }
+            this.dirty();
         },
 
         setImage: function ( img, imageFormat ) {
@@ -329,8 +340,12 @@ define( [
 
         applyFilterParameter: function ( gl, target ) {
 
+
             var powerOfTwo = isPowerOf2( this._textureWidth ) && isPowerOf2( this._textureHeight );
             if ( !powerOfTwo ) {
+                // NPOT non support in webGL explained here
+                // https://www.khronos.org/webgl/wiki/WebGL_and_OpenGL_Differences#Non-Power_of_Two_Texture_Support
+                // so disabling mipmap...
                 this.setWrapT( Texture.CLAMP_TO_EDGE );
                 this.setWrapS( Texture.CLAMP_TO_EDGE );
 
@@ -339,9 +354,13 @@ define( [
                     this.setMinFilter( Texture.LINEAR );
                 }
             }
-
             gl.texParameteri( target, gl.TEXTURE_MAG_FILTER, this._magFilter );
             gl.texParameteri( target, gl.TEXTURE_MIN_FILTER, this._minFilter );
+
+            if ( this._maxAnisotropy > 1.0 ) {
+                gl.texParameterf( target, Texture.TEXTURE_MAX_ANISOTROPY_EXT, this._maxAnisotropy );
+            }
+
             gl.texParameteri( target, gl.TEXTURE_WRAP_S, this._wrapS );
             gl.texParameteri( target, gl.TEXTURE_WRAP_T, this._wrapT );
         },

--- a/sources/osgViewer/View.js
+++ b/sources/osgViewer/View.js
@@ -55,6 +55,11 @@ define( [
         initWebGLCaps: function ( gl ) {
             this._webGLCaps = new WebGLCaps( gl );
             this._webGLCaps.init();
+            var anisoExt = this._webGLCaps.getWebGLExtension( 'EXT_texture_filter_anisotropic' );
+            if ( anisoExt ) {
+                Texture.ANISOTROPIC_SUPPORT_EXT = true;
+                Texture.ANISOTROPIC_SUPPORT_MAX = gl.getParameter( anisoExt.MAX_TEXTURE_MAX_ANISOTROPY_EXT );
+            }
         },
 
         computeCanvasSize: ( function () {
@@ -183,11 +188,10 @@ define( [
                 }
             }
         },
-        flushDeletedGLObjects: function ( /*currentTime,*/ availableTime )
-        {
-            // Flush all deleted OpenGL objects within the specified availableTime 
+        flushDeletedGLObjects: function ( /*currentTime,*/ availableTime ) {
+            // Flush all deleted OpenGL objects within the specified availableTime
             Texture.textureManager.flushDeletedTextureObjects( this.getGraphicContext(), availableTime );
-            // More GL Objects.... 
+            // More GL Objects....
         }
 
     };


### PR DESCRIPTION
- Much better quality when enabled, gracefully handle non supporting (<3%) and multiplier set to > max hardware aniso supported
- added comments (notably the NPOT thing whe should check)
- commented the releaseGLobject that was emptying this._image, which was preventing user side dirty/recreation of gl object from same image when you just change the texture parameters. (ought to be much more friendly, that... osgjs user would expect setting a magfilter would work without him having to manually realase the gl object.)
