### PR TITLE
Static Shadow support & better shadow traversal mask support

### DIFF
--- a/examples/shadowmap/main.js
+++ b/examples/shadowmap/main.js
@@ -700,7 +700,9 @@
             if ( this._previousTech !== this._config[ 'shadow' ] ) {
                 // technique change.
 
-                this._groundNode.setNodeMask( ~this._castsShadowTraversalMask );
+
+                this._groundNode.setNodeMask( ~( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask ) );
+
                 switch ( this._config[ 'shadow' ] ) {
                 case 'ESM':
 
@@ -1088,7 +1090,8 @@
             var mapres = parseInt( this._config[ 'textureSize' ] );
             shadowSettings.setTextureSize( mapres );
 
-            shadowSettings.setCastsShadowTraversalMask( this._castsShadowTraversalMask );
+            shadowSettings.setCastsShadowDrawTraversalMask( this._castsShadowDrawTraversalMask );
+            shadowSettings.setCastsShadowBoundsTraversalMask( this._castsShadowBoundsTraversalMask );
 
             shadowSettings.setAlgorithm( this._config[ 'shadow' ] );
 
@@ -1176,7 +1179,8 @@
         createScene: function () {
             var group = new osg.Node();
 
-            this._castsShadowTraversalMask = 0x2;
+            this._castsShadowDrawTraversalMask = 0x2;
+            this._castsShadowBoundsTraversalMask = 0x4;
 
             this._shadowScene = this.createSceneCasterReceiver();
 
@@ -1187,9 +1191,13 @@
             // casting shadow
             // receiving shadow
             // any combination possible.
-            //this._shadowScene.setNodeMask( this._castsShadowTraversalMask );
+            //this._shadowScene.setNodeMask( this._castsShadowDrawTraversalMask );
             //this._shadowScene.setNodeMask( this._receivesShadowTraversalMask );
-            this._groundNode.setNodeMask( ~this._castsShadowTraversalMask );
+
+
+            this._cubeNode.setNodeMask( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask );
+            this._modelNode.setNodeMask( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask );
+            this._groundNode.setNodeMask( ~( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask ) );
 
             /////////////////////////
             shadowedScene.addChild( this._shadowScene );

--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -130,6 +130,10 @@ define( [
 
         this._computeFrustumBounds = new ShadowFrustumIntersection();
         this._computeBoundsVisitor = new ComputeBoundsVisitor();
+
+        // true if shadow map rendered at least once
+        // since dirtied, handy for static shadow map
+        this._filledOnce = false;
     };
 
     /** @lends ShadowMap.prototype */
@@ -145,6 +149,10 @@ define( [
 
         isDirty: function () {
             return this._dirty;
+        },
+
+        isFilledOnce: function () {
+            return this._filledOnce;
         },
 
         setShadowCasterShaderProgram: function ( prg ) {
@@ -807,12 +815,14 @@ define( [
 
             // reapply the original traversal mask
             cullVisitor.setTraversalMask( traversalMask );
+            this._filledOnce = true;
         },
 
 
         cleanSceneGraph: function () {
             // well release a lot more things when it works
             this._cameraShadow = undefined;
+            this._filledOnce = false;
 
 
             if ( this._receivingStateset ) {

--- a/sources/osgShadow/ShadowSettings.js
+++ b/sources/osgShadow/ShadowSettings.js
@@ -13,7 +13,8 @@ define( [
      */
     var ShadowSettings = function ( options ) {
 
-        this.castsShadowTraversalMask = 0xffffffff;
+        this.castsShadowDrawTraversalMask = 0xffffffff;
+        this.castsShadowBoundsTraversalMask = 0xffffffff;
 
         this.textureSize = 1024;
 
@@ -85,11 +86,18 @@ define( [
 
     ShadowSettings.prototype = {
 
-        setCastsShadowTraversalMask: function ( mask ) {
-            this.castsShadowTraversalMask = mask;
+        setCastsShadowDrawTraversalMask: function ( mask ) {
+            this.castsShadowDrawTraversalMask = mask;
         },
-        getCastsShadowTraversalMask: function () {
-            return this.castsShadowTraversalMask;
+        getCastsShadowDrawTraversalMask: function () {
+            return this.castsDrawShadowTraversalMask;
+        },
+
+        setCastsShadowBoundsTraversalMask: function ( mask ) {
+            this.castsShadowBoundsTraversalMask = mask;
+        },
+        getCastsShadowBoundsTraversalMask: function () {
+            return this.castsShadowBoundsTraversalMask;
         },
 
         setLightSource: function ( lightSource ) {

--- a/sources/osgShadow/ShadowTechnique.js
+++ b/sources/osgShadow/ShadowTechnique.js
@@ -12,10 +12,12 @@ define( [
     var ShadowTechnique = function () {
         Object.call( this );
 
-        this._enabled = true;
         this._shadowedScene = undefined;
         this._dirty = false;
-
+        // need to be computed
+        this._enabled = true;
+        // since dirtied, handy for static shadow map
+        this._filledOnce = false;
     };
 
     /** @lends ShadowTechnique.prototype */
@@ -37,6 +39,10 @@ define( [
             return this._enabled;
         },
 
+        isFilledOnce: function () {
+            return this._filledOnce;
+        },
+
         setShadowedScene: function ( shadowedScene ) {
             this._shadowedScene = shadowedScene;
         },
@@ -52,9 +58,9 @@ define( [
         },
 
         // update the technic
-        updateShadowTechnic: function ( /*nodeVisitor*/ ) {},
+        updateShadowTechnic: function ( /*nodeVisitor*/) {},
 
-        cullShadowCasting: function ( /*cullVisitor*/ ) {},
+        cullShadowCasting: function ( /*cullVisitor*/) {},
 
         cleanSceneGraph: function () {
             // well shouldn't be called

--- a/sources/osgShadow/ShadowedScene.js
+++ b/sources/osgShadow/ShadowedScene.js
@@ -77,41 +77,35 @@ define( [
         },
         traverse: function ( nv ) {
 
-            var i, st, lt = this._shadowTechniques.length;
 
             if ( nv.getVisitorType() === NodeVisitor.UPDATE_VISITOR ) {
 
-                // update all shadow technics
-                for ( i = 0; i < lt; i++ ) {
-                    st = this._shadowTechniques[ i ];
-
-                    if ( st && st.valid() ) {
-
-                        if ( st.isDirty() ) // if dirty init shadow techniques
-
-                            st.init();
-
-                        if ( st.getEnable() )
-                            st.updateShadowTechnic( nv );
-                    }
-                }
-
                 // update the scene
                 this.nodeTraverse( nv );
-
-
 
             } else if ( nv.getVisitorType() === NodeVisitor.CULL_VISITOR ) {
 
                 // cull Shadowed Scene
                 this.cullShadowReceivingScene( nv );
 
+                var i, st, lt = this._shadowTechniques.length;
                 // cull Casters
                 for ( i = 0; i < lt; i++ ) {
                     st = this._shadowTechniques[ i ];
                     // dirty check for user playing with shadows inside update traverse
-                    if ( st && st.getEnable() && st.valid() && !st.isDirty() ) {
-                        st.cullShadowCasting( nv );
+                    if ( st && st.valid() ) {
+
+                        // those two checks
+                        // here
+                        // in case people update it from
+                        // any update/cull/callback
+                        if ( st.isDirty() )
+                            st.init();
+
+                        if ( st.getEnable() || !st.isFilledOnce() ) {
+                            st.updateShadowTechnic( nv );
+                            st.cullShadowCasting( nv );
+                        }
                     }
                 }
 

--- a/sources/osgShadow/shaders/shadowsReceive.glsl
+++ b/sources/osgShadow/shaders/shadowsReceive.glsl
@@ -120,7 +120,9 @@ float computeShadow(in bool lighted,
     vec4 shadowUV;
 
     // depth bias
-    float shadowBias = 0.005*tan(acos(N_Dot_L)); // cosTheta is dot( n, l ), clamped between 0 and 1
+    //float shadowBias = 0.005*tan(acos(N_Dot_L)); // cosTheta is dot( n, l ), clamped between 0 and 1
+    // same but 4 cycles instead of 15
+    float shadowBias = 0.005 * sqrt( 1. -  N_Dot_L*N_Dot_L) / N_Dot_L;
     shadowBias = clamp(shadowBias, 0.0, bias);
 
     //normal offset aka Exploding Shadow Receivers


### PR DESCRIPTION
Adds shadowMap filledOnce property that allows ensuring static shadowMap is built once at least after a dirty/init
Splits Shadow caster Traversal Maks in two, allowing for bounds & drawselection (you want to draw shadows, but not taking it in account in our
bounds, etc.)