### PR TITLE
Packs two vec4 into one for shadow (overcoming firefox limitations)

### DIFF
--- a/examples/shadowmap/main.js
+++ b/examples/shadowmap/main.js
@@ -46,7 +46,7 @@
             '_spotCutoff': 25,
             '_spotBlend': 0.3,
             '_constantAttenuation': 0.0,
-            '_linearAttenuation': 0.005,
+            '_linearAttenuation': 0.001,
             '_quadraticAttenuation': 0.0,
             'exampleObj': this,
             'shadowStatic': false,
@@ -332,8 +332,8 @@
             // shaders has to have under max varying decl
             // max = this._maxVaryings -1
             // usual shader is already 4 vertexColor, FragNormal, FragEye, FragTexcoord.
-            // each shadow is 2 more.
-            var maxLights = ~~( ( this._maxVaryings - 1 ) - 4 ) / 2.0;
+            // each shadow is 1 more vec4 per shadow
+            var maxLights = ~~( ( this._maxVaryings - 1 ) - 4 );
 
             controller = gui.add( this._config, 'lightNum', 1, maxLights ).step( 1 );
             controller.onChange( this.updateShadow.bind( this ) );
@@ -539,7 +539,7 @@
         updateLightsEnable: function () {
             var l, numLights = ~~( this._config[ 'lightNum' ] );
 
-            while ( this._maxVaryings < ( numLights * 2 + 4 ) ) {
+            while ( this._maxVaryings < ( numLights + 4 ) ) {
                 numLights--;
             }
             this._config[ 'lightNum' ] = numLights;
@@ -550,7 +550,7 @@
 
             if ( this._lights.length !== numLights ) {
 
-                var lightScale = 1.0 / numLights;
+                var lightScale = 1.0 / ( numLights + 4 );
 
                 var group = this._viewer.getSceneData();
 
@@ -701,7 +701,7 @@
                 // technique change.
 
 
-                this._groundNode.setNodeMask( ~( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask ) );
+                this._groundNode.setNodeMask( ~( this._castsShadowBoundsTraversalMask | this._castsShadowTraversalMask ) );
 
                 switch ( this._config[ 'shadow' ] ) {
                 case 'ESM':
@@ -1048,6 +1048,7 @@
                 ground.getOrCreateStateSet().setTextureAttributeAndModes( 0, groundTex );
                 ground.getOrCreateStateSet().setAttributeAndModes( new osg.CullFace( osg.CullFace.DISABLE ), osg.StateAttribute.ON | osg.StateAttribute.OVERRIDE );
 
+                //ground.getOrCreateStateSet().setAttributeAndModes( new osg.BlendFunc( osg.BlendFunc.ONE, osg.BlendFunc.ONE_MINUS_SRC_ALPHA ) );
 
             } );
             var groundSubNode;
@@ -1180,7 +1181,8 @@
             var group = new osg.Node();
 
             this._castsShadowDrawTraversalMask = 0x2;
-            this._castsShadowBoundsTraversalMask = 0x4;
+            this._castsShadowBoundsTraversalMask = 0x2;
+            //this._castsShadowBoundsTraversalMask = 0x4;
 
             this._shadowScene = this.createSceneCasterReceiver();
 
@@ -1198,6 +1200,7 @@
             this._cubeNode.setNodeMask( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask );
             this._modelNode.setNodeMask( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask );
             this._groundNode.setNodeMask( ~( this._castsShadowBoundsTraversalMask | this._castsShadowDrawTraversalMask ) );
+            //this._groundNode.setNodeMask( ~this._castsShadowBoundsTraversalMask );
 
             /////////////////////////
             shadowedScene.addChild( this._shadowScene );

--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -604,7 +604,7 @@ define( [
             inputs = MACROUTILS.objectMix( inputs, shadowUniforms );
 
             // shadowTexture  Attribute uniforms AND varying
-            var tex, shadowVertexProjected, shadowZ;
+            var tex, shadowVertexProjected;
             // TODO: better handle multi texture shadow (CSM/PSM/etc.)
             for ( k = 0; k < shadowTextures.length; k++ ) {
 
@@ -620,10 +620,8 @@ define( [
 
                     // Varyings
                     shadowVertexProjected = this.getOrCreateVarying( 'vec4', shadowTexture.getVaryingName( 'VertexProjected' ) );
-                    shadowZ = this.getOrCreateVarying( 'vec4', shadowTexture.getVaryingName( 'Z' ) );
                     var shadowVarying = {
                         shadowVertexProjected: shadowVertexProjected,
-                        shadowZ: shadowZ,
                         lightEyeDir: inputs.lightEyeDir,
                         lightNDL: inputs.lightNDL
                     };
@@ -925,7 +923,6 @@ define( [
                 this._vertexShader.push( 'uniform vec4 ' + mapSize.getName() + ';' );
                 // varyings
                 this._vertexShader.push( 'varying vec4 ' + shadowTexture.getVaryingName( 'VertexProjected' ) + ';' );
-                this._vertexShader.push( 'varying vec4 ' + shadowTexture.getVaryingName( 'Z' ) + ';' );
                 hasShadows = true;
             }
 
@@ -981,11 +978,12 @@ define( [
 
                 // varyings
                 var shadowVertProj = shadowTexture.getVaryingName( 'VertexProjected' );
-                var shadowZ = shadowTexture.getVaryingName( 'Z' );
 
-
-                this._vertexShader.push( ' ' + shadowZ + ' = ' + shadowView + ' *  worldPosition;' );
-                this._vertexShader.push( ' ' + shadowVertProj + ' = ' + shadowProj + ' * ' + shadowZ + ';' );
+                this._vertexShader.push( 'vec4 shadowPos' + i + ' = ' + shadowView + ' *  worldPosition;' );
+                this._vertexShader.push( ' ' + shadowVertProj + ' = ' + shadowProj + ' * shadowPos' + i + ';' );
+                // varying packing using 1 vec4 fo both Projection vector & viewworld z pos
+                // and pre-linearize Z
+                this._vertexShader.push( ' ' + shadowVertProj + '.z  = shadowPos' + i + '.z ;' );
             }
         },
         // Meanwhile, here it is.

--- a/sources/osgShader/node/shadows.js
+++ b/sources/osgShader/node/shadows.js
@@ -34,7 +34,6 @@ define( [
             var inputs = [
                 this._inputs.lighted,
                 this._inputs.shadowVertexProjected,
-                this._inputs.shadowZ,
                 this._inputs.shadowTexture,
                 this._inputs.shadowTextureMapSize,
                 this._inputs.shadowTextureDepthRange,

--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -577,10 +577,21 @@ define( [
             // compute a up vector ensuring avoiding parallel vectors
             // not using this._lightUp because not
             // reverting to it once got the change here done once
-            var up = [ 0.0, 0.0, 1.0 ];
+            // [ 0.0, 0.0, 1.0 ];
+            var up = this._lightUp;
             if ( Math.abs( Vec3.dot( up, eyeDir ) ) >= 1.0 ) {
                 // another camera up
-                up = [ 1.0, 0.0, 0.0 ];
+                // [ 1.0, 0.0, 0.0 ];
+                if ( this._lightUp[ 0 ] === 1.0 ) {
+                    this._lightUp[ 0 ] = 0.0;
+                    this._lightUp[ 1 ] = 0.0;
+                    this._lightUp[ 2 ] = 1.0;
+                } else {
+                    this._lightUp[ 0 ] = 1.0;
+                    this._lightUp[ 1 ] = 0.0;
+                    this._lightUp[ 2 ] = 0.0;
+                }
+
             }
             Matrix.makeLookFromDirection( eyePos, Vec3.neg( eyeDir, this._tmpVecBis ), up, view );
 
@@ -593,6 +604,7 @@ define( [
         makeOrthoFromBoundingBox: function ( bbox, eyeDir, view, projection ) {
 
             var center = bbox.center( this._tmpVecTercio );
+
             var radius = bbox.radius();
             var diameter = radius + radius;
 
@@ -618,10 +630,21 @@ define( [
             // compute a up vector ensuring avoiding parallel vectors
             // not using this._lightUp because not
             // reverting to it once got the change here done once
-            var up = [ 0.0, 0.0, 1.0 ];
+            // [ 0.0, 0.0, 1.0 ];
+            var up = this._lightUp;
             if ( Math.abs( Vec3.dot( up, eyeDir ) ) >= 1.0 ) {
                 // another camera up
-                up = [ 1.0, 0.0, 0.0 ];
+                // [ 1.0, 0.0, 0.0 ];
+                if ( this._lightUp[ 0 ] === 1.0 ) {
+                    this._lightUp[ 0 ] = 0.0;
+                    this._lightUp[ 1 ] = 0.0;
+                    this._lightUp[ 2 ] = 1.0;
+                } else {
+                    this._lightUp[ 0 ] = 1.0;
+                    this._lightUp[ 1 ] = 0.0;
+                    this._lightUp[ 2 ] = 0.0;
+                }
+
             }
             //Matrix.makeLookFromDirection( eyePos, Vec3.neg( eyeDir, this._tmpVecBis ), up, view );
             Matrix.makeLookFromDirection( eyePos, eyeDir, up, view );
@@ -796,7 +819,8 @@ define( [
             this._cameraShadow.setEnableFrustumCulling( true );
             // enabling this makes for strange projection fuck up
             // (as in clamped too tight projection)
-            this._cameraShadow.setComputeNearFar( true );
+            var needNearFar = this._castsShadowDrawTraversalMask === this._castsShadowBoundsTraversalMask;
+            this._cameraShadow.setComputeNearFar( needNearFar );
 
 
             var bbox;
@@ -804,6 +828,7 @@ define( [
 
 
             this._computeBoundsVisitor.setTraversalMask( this._castsShadowBoundsTraversalMask );
+            this._computeBoundsVisitor.reset();
             this.getShadowedScene().accept( this._computeBoundsVisitor );
             bbox = this._computeBoundsVisitor.getBoundingBox();
 
@@ -820,7 +845,7 @@ define( [
             // Here culling is done, we do have near/far.
             // and cull/non-culled info
             // if we wanted a tighter frustum.
-            if ( this._castsShadowDrawTraversalMask === this._castsShadowBoundsTraversalMask ) {
+            if ( needNearFar ) {
                 this.frameShadowCastingFrustum( cullVisitor );
             }
 

--- a/sources/osgShadow/shaders/shadowsCastFrag.glsl
+++ b/sources/osgShadow/shaders/shadowsCastFrag.glsl
@@ -35,8 +35,9 @@ vec4 shadowDepthToEVSM(float depth)
 void main(void) {
     float depth;
     // distance to camera
-    depth =  - FragEyePos.z* FragEyePos.w;
-//    depth = (depth - Shadow_DepthRange.x )* Shadow_DepthRange.w;
+    depth =  -FragEyePos.z * FragEyePos.w;
+
+    //depth = (depth - Shadow_DepthRange.x )* Shadow_DepthRange.w;
     depth = depth  / Shadow_DepthRange.y;
 
 #if defined (_FLOATTEX) && defined(_PCF)


### PR DESCRIPTION
pack vertex xy in projection space with vertex z in view space so that we end with one vec4 instead of two. 
(firefox on windows has a stupid 8 varying limit)