### PR TITLE
Bugfix/shadowTransparencyAndShaderCompilerOptim

### DIFF
--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -768,14 +768,14 @@ define( [
             functor.call( functor, node );
         },
 
-        evaluateDefines: function ( node ) {
+        evaluateAndGatherField: function ( node, field ) {
 
             var func = function ( node ) {
 
-                if ( node.defines && this._map[ node.getID() ] === undefined ) {
+                if ( node[ field ] && this._map[ node.getID() ] === undefined ) {
 
                     this._map[ node.getID() ] = true;
-                    var c = node.defines();
+                    var c = node[ field ]();
                     // push all elements of the array on text array
                     // defines must return an array
                     Array.prototype.push.apply( this._text, c );
@@ -795,10 +795,11 @@ define( [
 
             var func = function ( node ) {
 
+                var id = node.getID();
                 if ( node.globalFunctionDeclaration &&
-                    this._map[ node.type ] === undefined ) {
+                    this._map[ id ] === undefined ) {
 
-                    this._map[ node.type ] = true;
+                    this._map[ id ] = true;
                     var c = node.globalFunctionDeclaration();
                     this._text.push( c );
 
@@ -1029,8 +1030,9 @@ define( [
 
             var vars = Object.keys( this._variables );
 
-            // defines are added by process shader
-            var defines = this.evaluateDefines( root );
+            // defines and extensions are added by process shader
+            var extensions = this.evaluateAndGatherField( root, 'extensions' );
+            var defines = this.evaluateAndGatherField( root, 'defines' );
 
             this._fragmentShader.push( '\n' );
             this._fragmentShader.push( this.evaluateGlobalVariableDeclaration( root ) );
@@ -1061,7 +1063,7 @@ define( [
             var shader = this._fragmentShader.join( '\n' );
             //osg.log('Fragment Shader');
 
-            shader = this._shaderProcessor.processShader( shader, defines );
+            shader = this._shaderProcessor.processShader( shader, defines, extensions );
 
             Notify.debug( shader );
             return shader;

--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -640,6 +640,26 @@ define( [
 
         },
 
+        // Shared var between lights and shadows
+        createCommonLightingVars: function ( materials, enumLights, numLights ) {
+
+            if ( numLights === 0 )
+                return {};
+
+            var lighted = this.createVariable( 'bool', 'lighted' );
+            var lightPos = this.createVariable( 'vec3', 'lightEyePos' );
+            var lightDir = this.createVariable( 'vec3', 'lightEyeDir' );
+            var lightNDL = this.createVariable( 'float', 'lightNDL' );
+
+            return {
+                lighted: lighted,
+                lightEyePos: lightPos,
+                lightEyeDir: lightDir,
+                lightNDL: lightNDL
+            };
+
+        },
+
         createLighting: function ( materials, overrideNodeName ) {
 
             var output = this.createVariable( 'vec3' );
@@ -652,17 +672,7 @@ define( [
                 HEMI: 'HemiLight'
             };
 
-
-            var lighted = this.createVariable( 'bool', 'lighted' );
-            var lightPos = this.createVariable( 'vec3', 'lightEyePos' );
-            var lightDir = this.createVariable( 'vec3', 'lightEyeDir' );
-            var lightNDL = this.createVariable( 'float', 'lightNDL' );
-            var lightOutShadowIn = {
-                lighted: lighted,
-                lightEyePos: lightPos,
-                lightEyeDir: lightDir,
-                lightNDL: lightNDL
-            };
+            var lightOutShadowIn = this.createCommonLightingVars( materials, enumToNodeName, this._lights.length );
 
             var materialUniforms = this.getOrCreateStateAttributeUniforms( this._material, 'material' );
             for ( var i = 0; i < this._lights.length; i++ ) {

--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -768,16 +768,32 @@ define( [
             functor.call( functor, node );
         },
 
+        // Gather a particular output field
+        // for now one of
+        // ['define', 'extensions']
+        //
+        // from a nodeGraph
+        //
+        // In case a node of same Type
+        // have different outputs (shadow with different defines)
+        // it use ID rather than Type as map index
+        // UNIQUE PER TYPE
+        // TODO: adds includes so that we can remove it from
+        // the eval Global Functions ?
         evaluateAndGatherField: function ( node, field ) {
 
             var func = function ( node ) {
 
-                if ( node[ field ] && this._map[ node.getID() ] === undefined ) {
+                var idx = node.getType();
+                if ( idx === undefined || idx === '' ) {
+                    Notify.error( 'Your node ' + node + ' has not type' );
+                }
+                if ( node[ field ] && this._map[ idx ] === undefined ) {
 
-                    this._map[ node.getID() ] = true;
+                    this._map[ idx ] = true;
                     var c = node[ field ]();
                     // push all elements of the array on text array
-                    // defines must return an array
+                    // node[field]()  must return an array
                     Array.prototype.push.apply( this._text, c );
 
                 }
@@ -791,17 +807,30 @@ define( [
             return func._text;
         },
 
+        // Gather a functions declartions of nodes
+        // from a nodeGraph
+        // (for now pragma include done here too. could be done with define/etc...)
+        // Node of same Type has to share
+        // exact same "node.globalFunctionDeclaration" output
+        // as it use Type rather than ID as map index
         evaluateGlobalFunctionDeclaration: function ( node ) {
 
             var func = function ( node ) {
 
-                var id = node.getID();
-                if ( node.globalFunctionDeclaration &&
-                    this._map[ id ] === undefined ) {
+                // UNIQUE PER TYPE
+                var idx = node.getType();
 
-                    this._map[ id ] = true;
+                if ( idx === undefined || idx === '' ) {
+                    Notify.error( 'Your node ' + node + ' has not type' );
+                }
+                if ( node.globalFunctionDeclaration &&
+                    this._map[ idx ] === undefined ) {
+
+                    this._map[ idx ] = true;
                     var c = node.globalFunctionDeclaration();
-                    this._text.push( c );
+                    if ( c !== undefined ) {
+                        this._text.push( c );
+                    }
 
                 }
 
@@ -814,22 +843,26 @@ define( [
             return func._text.join( '\n' );
         },
 
+        // Gather a Variables declarations of nodes
+        // from a nodeGraph to be outputted
+        // outside the VOID MAIN code
+        // ( Uniforms, Varying )
+        // Node of same Type has different output
+        // as it use Type rather than ID as map index
         evaluateGlobalVariableDeclaration: function ( node ) {
 
             var func = function ( node ) {
 
-                var id = node.getID();
-                if ( this._map[ id ] === undefined ) {
+                // UNIQUE PER NODE
+                var idx = node.getID();
 
-                    this._map[ id ] = true;
+                if ( node.globalDeclaration &&
+                    this._map[ idx ] === undefined ) {
 
-                    if ( node.globalDeclaration !== undefined ) {
-
-                        var c = node.globalDeclaration();
-                        if ( c !== undefined ) {
-                            this._text.push( c );
-                        }
-
+                    this._map[ idx ] = true;
+                    var c = node.globalDeclaration();
+                    if ( c !== undefined ) {
+                        this._text.push( c );
                     }
                 }
             };

--- a/sources/osgShader/ShaderProcessor.js
+++ b/sources/osgShader/ShaderProcessor.js
@@ -92,9 +92,9 @@ define( [
             return preShader;
         },
 
-        getShader: function ( shaderName, defines ) {
+        getShader: function ( shaderName, defines, extensions ) {
             var shader = this.getShaderTextPure( shaderName );
-            return this.processShader( shader, defines );
+            return this.processShader( shader, defines, extensions );
         },
 
         // recursively  handle #include external glsl
@@ -156,7 +156,7 @@ define( [
         //  resolving include dependencies
         //  adding defines
         //  adding line instrumenting.
-        processShader: function ( shader, defines ) {
+        processShader: function ( shader, defines, extensions ) {
 
             var includeList = [];
             var preShader = shader;
@@ -172,10 +172,27 @@ define( [
                     return !pos || item !== defines[ pos - 1 ];
                 } );
             }
+            if ( extensions !== undefined ) {
+                extensions = extensions.sort().filter( function ( item, pos ) {
+                    return !pos || item !== extensions[ pos - 1 ];
+                } );
+            }
 
             var postShader = this.preprocess( preShader, sourceID, includeList, defines );
 
             var prePrend = '';
+
+            // prePrend += '#version 100'; // optional
+
+            // then
+            // it's extensions first
+            // See https://khronos.org/registry/gles/specs/2.0/GLSL_ES_Specification_1.0.17.pdf
+            // p14-15: before any non-processor token
+            // add them
+            if ( extensions !== undefined ) {
+                // could add an extension check support warning there...
+                prePrend += extensions.join( '\n' ) + '\n';
+            }
 
             if ( this._globalDefaultprecision ) {
                 if ( !this._precisionR.test( postShader ) ) {

--- a/sources/osgShader/ShaderProcessor.js
+++ b/sources/osgShader/ShaderProcessor.js
@@ -181,8 +181,7 @@ define( [
             var postShader = this.preprocess( preShader, sourceID, includeList, defines );
 
             var prePrend = '';
-
-            // prePrend += '#version 100'; // optional
+            prePrend += '#version 100\n'; // webgl1  (webgl2 #version 130 ?)
 
             // then
             // it's extensions first

--- a/sources/osgShader/node/Node.js
+++ b/sources/osgShader/node/Node.js
@@ -9,7 +9,18 @@ define( [
         this._name = 'AbstractNode';
         this._inputs = [];
         this._outputs = null;
+
+        // category of node
+        // same name implies same
+        // define/function
+        //this.type = '';
+
+        // uuid: unicity
+        // allows multipe node of same type
+        // declaring multipe code paths
+        // inside the main
         this._id = instance++;
+
         this._text = undefined;
     };
 
@@ -17,6 +28,10 @@ define( [
 
         getID: function () {
             return this._id;
+        },
+
+        getType: function () {
+            return this.type;
         },
 
         toString: function () {

--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -30,6 +30,7 @@ define( [
 
     var TransparentRemoveVisitor = function ( mask ) {
         NodeVisitor.call( this );
+        // mask setting to avoid casting shadows
         this._noCastMask = mask;
         this._nodeList = [];
     };
@@ -45,11 +46,14 @@ define( [
                 if ( blend !== undefined && blend.getSource() !== BlendFunc.DISABLE ) {
                     /*jshint bitwise: false */
                     var nm = node.getNodeMask();
+                    // ~0x0 as not to be processed
                     if ( nm === ~0x0 ) {
+                        // set to avoid casting shadow
                         nm = this._noCastMask;
                         node.setNodeMask( nm );
                         this._nodeList.push( node );
                     } else if ( ( nm & ~( this._noCastMask ) ) !== 0 ) {
+                        // set to avoid casting shadow
                         node.setNodeMask( nm | this._noCastMask );
                         this._nodeList.push( node );
                     }
@@ -62,6 +66,8 @@ define( [
         setNoCastMask: function ( mask ) {
             this._noCastMask = mask;
         },
+        // restore to any previous mask avoiding any breaks
+        // in other application mask usage.
         restore: function () {
             var node, i = this._nodeList.length;
             while ( i-- ) {

--- a/tests/osg/osgTests.js
+++ b/tests/osg/osgTests.js
@@ -19,7 +19,6 @@ define( [
     'tests/osg/PagedLOD',
     'tests/osg/Plane',
     'tests/osg/Quat',
-    'tests/osg/ShaderGenerator',
     'tests/osg/State',
     'tests/osg/StateSet',
     'tests/osg/Texture',
@@ -29,7 +28,7 @@ define( [
     'tests/osg/Uniform',
     'tests/osg/Vec2',
     'tests/osg/PrimitiveFunctor'
-], function ( Image, BlendColor, BoundingBox, BoundingSphere, BufferArray, Camera, ComputeBoundsVisitor, ComputeMatrixFromNodePath, CullFace, CullVisitor, Depth, KdTree, Light, Matrix, MatrixTransform, Node, NodeVisitor, PagedLOD, Plane, Quat, ShaderGenerator, State, StateSet, Texture, TextureCubeMap, TextureManager, UpdateVisitor, Uniform, Vec2, PrimitiveFunctor ) {
+], function ( Image, BlendColor, BoundingBox, BoundingSphere, BufferArray, Camera, ComputeBoundsVisitor, ComputeMatrixFromNodePath, CullFace, CullVisitor, Depth, KdTree, Light, Matrix, MatrixTransform, Node, NodeVisitor, PagedLOD, Plane, Quat, State, StateSet, Texture, TextureCubeMap, TextureManager, UpdateVisitor, Uniform, Vec2, PrimitiveFunctor ) {
 
     'use strict';
 
@@ -54,7 +53,6 @@ define( [
         Plane();
         PagedLOD();
         Quat();
-        ShaderGenerator();
         State();
         StateSet();
         Texture();

--- a/tests/osgShader/Compiler.js
+++ b/tests/osgShader/Compiler.js
@@ -1,0 +1,72 @@
+define( [
+    'tests/mockup/mockup',
+    'osg/Light',
+    'osg/LightSource',
+    'osg/Material',
+    'osgShader/Compiler',
+    'osgShadow/ShadowAttribute',
+    'osgShadow/ShadowTexture'
+], function ( mockup, Light, LightSource, Material, Compiler, ShadowAttribute, ShadowTexture ) {
+
+    return function () {
+
+        module( 'osgShader' );
+
+        test( 'Compiler', function () {
+
+            ( function () {
+
+                var light = new Light( 1 );
+                var lightSource = new LightSource();
+                lightSource.setLight( light );
+                var shadowAttribute = new ShadowAttribute();
+                var shadowTexture = new ShadowTexture();
+                shadowAttribute.setLight( light );
+                shadowTexture.setLightUnit( light.getLightNumber() );
+
+                var material = new Material();
+                var compiler = new Compiler( [ light, material, shadowAttribute ], [
+                    [ shadowTexture ]
+                ] );
+
+                var root = compiler.createFragmentShaderGraph();
+
+                var extensions = compiler.evaluateAndGatherField( root, 'extensions' );
+                ok( extensions.length === 0, 'Compiler Evaluate And Gather Field: defines rightly so' );
+                var defines = compiler.evaluateAndGatherField( root, 'defines' );
+                ok( defines.length === 1, 'Compiler Evaluate And Gather Field: defines rightly so' );
+
+
+                var globalDecl = compiler.evaluateGlobalVariableDeclaration( root );
+                ok( globalDecl.length > 1, 'Compiler Evaluate Global Variables output smth' );
+
+                globalDecl = globalDecl.split( '\n' );
+                var hasDoublons = false;
+                globalDecl.sort().filter( function ( item, pos ) {
+                    if ( !hasDoublons && item === globalDecl[ pos - 1 ] ) hasDoublons = true;
+                    return !pos || item !== globalDecl[ pos - 1 ];
+                } );
+                ok( !hasDoublons, 'Compiler Evaluate Global Variables Declaration output no doublons' );
+
+
+                globalDecl = compiler.evaluateGlobalFunctionDeclaration( root );
+                ok( globalDecl.length > 1, 'Compiler Evaluate Global Functions Declaration output smth' );
+
+                /*
+                 // sadly doesn't work as is for functions decl.
+                 // needs glsl parsing...
+                 var hasDoublons = false;
+                 globalDecl.sort().filter( function ( item, pos ) {
+                    if ( !hasDoublons && item === globalDecl[ pos - 1 ] ) hasDoublons = true;
+                    return !pos || item !== globalDecl[ pos - 1 ];
+                } );
+
+                var globalDecl = compiler.evaluateGlobalFunctionDeclaration( root );
+                ok( !hasDoublons, 'Compiler Evaluate Global Functions Declaration output no doublons' );
+                 */
+
+            } )();
+
+        } );
+    };
+} );

--- a/tests/osgShader/ShaderGenerator.js
+++ b/tests/osgShader/ShaderGenerator.js
@@ -11,7 +11,7 @@ define( [
 
     return function () {
 
-        module( 'osg' );
+        module( 'osgShader' );
 
         test( 'ShaderGenerator', function () {
 

--- a/tests/osgShader/osgShaderTests.js
+++ b/tests/osgShader/osgShaderTests.js
@@ -1,0 +1,10 @@
+define( [
+    'tests/osgShader/Compiler',
+    'tests/osgShader/ShaderGenerator',
+], function ( Compiler, ShaderGenerator ) {
+
+    return function () {
+        Compiler();
+        ShaderGenerator();
+    };
+} );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -50,9 +50,10 @@ define( [
     'tests/osgGA/osgGATests',
     'tests/osgUtil/osgUtilTests',
     'tests/osgViewer/osgViewerTests',
-    'tests/osgShadow/osgShadowTests',
+    'tests/osgShader/osgShaderTests',
+    'tests/osgShadow/osgShadowTests'
 
-], function ( OSG, osg, osgAnimation, osgDB, osgGA, osgUtil, osgViewer, osgShadow ) {
+], function ( OSG, osg, osgAnimation, osgDB, osgGA, osgUtil, osgViewer, osgShader, osgShadow ) {
 
     // hack because of osgPool
     OSG.osg.init();
@@ -63,6 +64,7 @@ define( [
     osgGA();
     osgUtil();
     osgViewer();
+    osgShader();
     osgShadow();
     // start test when require finished its job
     QUnit.load();


### PR DESCRIPTION
- Fix empty shadowmap case (could spout NaN and correctness depended on broswer handling
- Optimizes empty shadowmap case with early detection in the shader (depthRange.x == depthRange.y) and early out of shadow shader. (along with pushing computation after the early out)
- Makes CreateLighting more modular for shared vars between lights ( allow for optimisation when many lights and all use non light dependant precomputations.)
- Adds Extensions support to shaderprocessor and node shader compiler, …
following the GLSL spec (extension should be define before any non
processor instructions in shader compilation unit)