### PR TITLE
Fix shadow texture unit wrong on recreation if not using default 4

### DIFF
--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -479,7 +479,6 @@ define( [
 
             if ( !this._texture ) {
                 this._texture = new ShadowTexture();
-                this._textureUnitBase = 4;
                 this._textureUnit = this._textureUnitBase;
             }
 


### PR DESCRIPTION
Fix shadow texture unit wrong on recreation if not using default 4 as start