### PR TITLE
Added a TextureManager Map to store a TextureManager for each GraphicCon...

### DIFF
--- a/sources/osg/BufferArray.js
+++ b/sources/osg/BufferArray.js
@@ -32,6 +32,7 @@ define( [
                 this._elements = elements instanceof MACROUTILS.Float32Array ? elements : new MACROUTILS.Float32Array( elements );
             }
         }
+        this._gl = undefined;
     };
 
     BufferArray.ELEMENT_ARRAY_BUFFER = 0x8893;
@@ -84,15 +85,15 @@ define( [
             return false;
         },
 
-        releaseGLObjects: function ( state ) {
-            if ( this._buffer !== undefined && this._buffer !== null ) {
-                BufferArray.deleteGLBufferArray( state.getGraphicContext(), this._buffer );
+        releaseGLObjects: function () {
+            if ( this._buffer !== undefined && this._buffer !== null && this._gl !== undefined ) {
+                BufferArray.deleteGLBufferArray( this._gl, this._buffer );
             }
             this._buffer = undefined;
         },
 
         bind: function ( gl ) {
-
+            if ( !this._gl ) this._gl = gl;
             var type = this._type;
             var buffer = this._buffer;
 

--- a/sources/osg/BufferArray.js
+++ b/sources/osg/BufferArray.js
@@ -2,9 +2,10 @@ define( [
     'osg/Utils',
     'osg/Notify',
     'osg/Object',
+    'osg/GLObject',
     'osg/Timer'
 
-], function ( MACROUTILS, Notify, Object, Timer ) {
+], function ( MACROUTILS, Notify, Object, GLObject, Timer ) {
 
     'use strict';
 
@@ -13,7 +14,7 @@ define( [
      * @class BufferArray
      */
     var BufferArray = function ( type, elements, itemSize ) {
-
+        GLObject.call( this );
         // maybe could inherit from Object
         this._instanceID = Object.getInstanceID();
 
@@ -32,15 +33,10 @@ define( [
                 this._elements = elements instanceof MACROUTILS.Float32Array ? elements : new MACROUTILS.Float32Array( elements );
             }
         }
-        this._gl = undefined;
     };
 
     BufferArray.ELEMENT_ARRAY_BUFFER = 0x8893;
     BufferArray.ARRAY_BUFFER = 0x8892;
-
-
-    // Does make sense to have a BufferObjectManager? could be helpful if having different contexts?
-    // For now use a static Map to track objects to be deleted
 
     // static cache of glBuffers flagged for deletion, which will actually
     // be deleted in the correct GL context.
@@ -73,7 +69,7 @@ define( [
 
 
     /** @lends BufferArray.prototype */
-    BufferArray.prototype = {
+    BufferArray.prototype = MACROUTILS.objectInherit( GLObject.prototype, {
         setItemSize: function ( size ) {
             this._itemSize = size;
         },
@@ -93,7 +89,7 @@ define( [
         },
 
         bind: function ( gl ) {
-            if ( !this._gl ) this._gl = gl;
+            if ( !this._gl ) this.setGraphicContext( gl );
             var type = this._type;
             var buffer = this._buffer;
 
@@ -131,7 +127,7 @@ define( [
             this._elements = elements;
             this._dirty = true;
         }
-    };
+    } );
 
     BufferArray.create = function ( type, elements, itemSize ) {
         Notify.log( 'BufferArray.create is deprecated, use new BufferArray with same arguments instead' );

--- a/sources/osg/GLObject.js
+++ b/sources/osg/GLObject.js
@@ -1,0 +1,24 @@
+define( [
+], function () {
+
+    'use strict';
+
+    // Base class for GLResources: Textures, Buffers, Programs, Shaders, FrameBuffers and RenderBuffers
+    // It holds a reference to the graphic context that is needed for resource deletion
+
+    var GLObject = function ( ) {
+        this._gl = undefined;
+    };
+
+    GLObject.prototype = {
+        setGraphicContext: function ( gl ) {
+            this._gl = gl;
+        },
+        getGraphicContext: function () {
+            return this._gl;
+        }
+    };
+
+    return GLObject;
+
+});

--- a/sources/osg/Geometry.js
+++ b/sources/osg/Geometry.js
@@ -23,17 +23,17 @@ define( [
 
     /** @lends Geometry.prototype */
     Geometry.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( Node.prototype, {
-        releaseGLObjects: function ( gl ) {
-            if ( this.stateset !== undefined ) this.stateset.releaseGLObjects();
+        releaseGLObjects: function ( state ) {
+            this.stateset.releaseGLObjects( state );
             var i;
             for ( i in this.attributes ) {
-                this.attributes[ i ].releaseGLObjects( gl );
+                this.attributes[ i ].releaseGLObjects( state.getGraphicContext() );
             }
             for ( var j = 0, l = this.primitives.length; j < l; j++ ) {
                 var prim = this.primitives[ j ];
                 if ( prim.getIndices !== undefined ) {
                     if ( prim.getIndices() !== undefined && prim.getIndices() !== null ) {
-                        prim.indices.releaseGLObjects( gl );
+                        prim.indices.releaseGLObjects( state.getGraphicContext() );
                     }
                 }
             }

--- a/sources/osg/Geometry.js
+++ b/sources/osg/Geometry.js
@@ -23,17 +23,17 @@ define( [
 
     /** @lends Geometry.prototype */
     Geometry.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( Node.prototype, {
-        releaseGLObjects: function ( state ) {
-            this.stateset.releaseGLObjects( state );
+        releaseGLObjects: function () {
+            this.stateset.releaseGLObjects();
             var i;
             for ( i in this.attributes ) {
-                this.attributes[ i ].releaseGLObjects( state );
+                this.attributes[ i ].releaseGLObjects();
             }
             for ( var j = 0, l = this.primitives.length; j < l; j++ ) {
                 var prim = this.primitives[ j ];
                 if ( prim.getIndices !== undefined ) {
                     if ( prim.getIndices() !== undefined && prim.getIndices() !== null ) {
-                        prim.indices.releaseGLObjects( state );
+                        prim.indices.releaseGLObjects();
                     }
                 }
             }

--- a/sources/osg/Geometry.js
+++ b/sources/osg/Geometry.js
@@ -27,13 +27,13 @@ define( [
             this.stateset.releaseGLObjects( state );
             var i;
             for ( i in this.attributes ) {
-                this.attributes[ i ].releaseGLObjects( state.getGraphicContext() );
+                this.attributes[ i ].releaseGLObjects( state );
             }
             for ( var j = 0, l = this.primitives.length; j < l; j++ ) {
                 var prim = this.primitives[ j ];
                 if ( prim.getIndices !== undefined ) {
                     if ( prim.getIndices() !== undefined && prim.getIndices() !== null ) {
-                        prim.indices.releaseGLObjects( state.getGraphicContext() );
+                        prim.indices.releaseGLObjects( state );
                     }
                 }
             }

--- a/sources/osg/Node.js
+++ b/sources/osg/Node.js
@@ -333,8 +333,8 @@ define( [
             return this._numChildrenWithCullingDisabled;
         },
 
-        releaseGLObjects: function ( state ) {
-            if ( this.stateset !== undefined ) this.stateset.releaseGLObjects( state );
+        releaseGLObjects: function () {
+            if ( this.stateset !== undefined ) this.stateset.releaseGLObjects();
         }
 
     } ), 'osg', 'Node' );

--- a/sources/osg/Node.js
+++ b/sources/osg/Node.js
@@ -333,8 +333,8 @@ define( [
             return this._numChildrenWithCullingDisabled;
         },
 
-        releaseGLObjects: function ( /*gl*/) {
-            if ( this.stateset !== undefined ) this.stateset.releaseGLObjects();
+        releaseGLObjects: function ( state ) {
+            if ( this.stateset !== undefined ) this.stateset.releaseGLObjects( state );
         }
 
     } ), 'osg', 'Node' );

--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -1,10 +1,11 @@
 define( [
     'osg/Utils',
     'osg/Notify',
+    'osg/GLObject',
     'osg/StateAttribute',
     'osg/Map',
     'osg/Timer'
-], function ( MACROUTILS, Notify, StateAttribute, CustomMap, Timer ) {
+], function ( MACROUTILS, Notify, GLObject, StateAttribute, CustomMap, Timer ) {
     'use strict';
 
     /**
@@ -12,8 +13,8 @@ define( [
      * @class Program
      */
     var Program = function ( vShader, fShader ) {
+        GLObject.call( this );
         StateAttribute.call( this );
-
         this._program = null;
 
         // used to know if it's a default program
@@ -34,7 +35,6 @@ define( [
 
         if ( fShader )
             this.setFragmentShader( fShader );
-        this._gl = undefined;
     };
 
     // static cache of glPrograms flagged for deletion, which will actually
@@ -66,7 +66,7 @@ define( [
     };
 
     /** @lends Program.prototype */
-    Program.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( StateAttribute.prototype, {
+    Program.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( GLObject.prototype, MACROUTILS.objectInherit( StateAttribute.prototype, {
 
         attributeType: 'Program',
 
@@ -111,7 +111,7 @@ define( [
             if ( this._nullProgram ) return;
 
             if ( !this._gl ) {
-                this._gl = state.getGraphicContext();
+                this.setGraphicContext( state.getGraphicContext() );
             }
             var gl = this._gl;
             if ( !this._program || this.isDirty() ) {
@@ -228,7 +228,7 @@ define( [
                 }
             }
         }
-    } ), 'osg', 'Program' );
+    } ) ), 'osg', 'Program' );
 
     return Program;
 } );

--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -34,6 +34,7 @@ define( [
 
         if ( fShader )
             this.setFragmentShader( fShader );
+        this._gl = undefined;
     };
 
     // static cache of glPrograms flagged for deletion, which will actually
@@ -94,14 +95,13 @@ define( [
             return this._program;
         },
 
-        releaseGLObjects: function ( state ) {
+        releaseGLObjects: function ( ) {
             // Call to releaseGLOBjects on shaders
-            if ( this._vertex !== undefined ) this._vertex.releaseGLObjects( state );
-            if ( this._fragment !== undefined ) this._fragment.releaseGLObjects( state );
-            if ( this._program == null ) return;
-            if ( state !== undefined ) {
-                // Programs only can be removed from a explicit context
-                Program.deleteGLProgram( state.getGraphicContext(), this._program );
+            if ( this._vertex !== undefined ) this._vertex.releaseGLObjects();
+            if ( this._fragment !== undefined ) this._fragment.releaseGLObjects();
+            if ( this._program === null ) return;
+            if ( this._gl !== undefined ) {
+                    Program.deleteGLProgram( this._gl, this._program );
             }
             this._program = undefined;
         },
@@ -110,8 +110,10 @@ define( [
 
             if ( this._nullProgram ) return;
 
-            var gl = state.getGraphicContext();
-
+            if ( !this._gl ) {
+                this._gl = state.getGraphicContext();
+            }
+            var gl = this._gl;
             if ( !this._program || this.isDirty() ) {
 
                 var compileClean;

--- a/sources/osg/Shader.js
+++ b/sources/osg/Shader.js
@@ -1,22 +1,22 @@
 define( [
     'osg/Notify',
     'osg/Utils',
-    'osg/Timer'
-], function ( Notify, Utils, Timer ) {
+    'osg/Timer',
+    'osg/GLObject'
+], function ( Notify, MACROUTILS, Timer, GLObject ) {
 
     /**
      * Shader manage shader for vertex and fragment, you need both to create a glsl program.
      * @class Shader
      */
     var Shader = function ( type, text ) {
-
+        GLObject.call( this );
         var t = type;
         if ( typeof ( type ) === 'string' ) {
             t = Shader[ type ];
         }
         this.type = t;
         this.setText( text );
-        this._gl = undefined;
     };
 
     Shader.VERTEX_SHADER = 0x8B31;
@@ -56,7 +56,7 @@ define( [
     };
 
     /** @lends Shader.prototype */
-    Shader.prototype = {
+    Shader.prototype = MACROUTILS.objectInherit( GLObject.prototype, {
         setText: function ( text ) {
             this.text = text;
         },
@@ -111,10 +111,10 @@ define( [
             }
         },
         compile: function ( gl ) {
-            if ( !this._gl ) this._gl = gl;
+            if ( !this._gl ) this.setGraphicContext( gl );
             this.shader = gl.createShader( this.type );
             gl.shaderSource( this.shader, this.text );
-            Utils.timeStamp( 'osgjs.metrics:compileShader' );
+            MACROUTILS.timeStamp( 'osgjs.metrics:compileShader' );
             gl.compileShader( this.shader );
             if ( !gl.getShaderParameter( this.shader, gl.COMPILE_STATUS ) && !gl.isContextLost() ) {
 
@@ -141,7 +141,7 @@ define( [
             }
             this.shader = undefined;
         }
-    };
+    } );
 
     Shader.create = function ( type, text ) {
         Notify.log( 'Shader.create is deprecated, use new Shader with the same arguments instead' );

--- a/sources/osg/Shader.js
+++ b/sources/osg/Shader.js
@@ -16,6 +16,7 @@ define( [
         }
         this.type = t;
         this.setText( text );
+        this._gl = undefined;
     };
 
     Shader.VERTEX_SHADER = 0x8B31;
@@ -110,6 +111,7 @@ define( [
             }
         },
         compile: function ( gl ) {
+            if ( !this._gl ) this._gl = gl;
             this.shader = gl.createShader( this.type );
             gl.shaderSource( this.shader, this.text );
             Utils.timeStamp( 'osgjs.metrics:compileShader' );
@@ -133,10 +135,9 @@ define( [
             }
             return true;
         },
-        releaseGLObjects: function ( state ) {
-            if ( state !== undefined ) {
-                // Shaders only can be removed from a explicit context
-                Shader.deleteGLShader( state.getGraphicContext(), this.shader );
+        releaseGLObjects: function () {
+            if ( this._gl !== undefined ) {
+                Shader.deleteGLShader( this._gl, this.shader );
             }
             this.shader = undefined;
         }

--- a/sources/osg/State.js
+++ b/sources/osg/State.js
@@ -6,10 +6,10 @@ define( [
     'osg/Program',
     'osg/StateAttribute',
     'osg/Stack',
-    'osg/TextureManager',
+    'osg/Texture',
     'osg/Uniform',
     'osg/Utils'
-], function ( Map, Matrix, Notify, Object, Program, StateAttribute, Stack, TextureManager, Uniform, MACROUTILS ) {
+], function ( Map, Matrix, Notify, Object, Program, StateAttribute, Stack, Texture, Uniform, MACROUTILS ) {
 
     'use strict';
 
@@ -56,8 +56,7 @@ define( [
 
         // texture manager is referenced here because it's associated with gl object
         // of the gl context intialized with State
-        this._textureManager = new TextureManager();
-
+        this._textureManager = Texture.getTextureManager( this._graphicContext );
 
         // we dont use Map because in this use case with a few entries
         // {} is faster

--- a/sources/osg/State.js
+++ b/sources/osg/State.js
@@ -54,10 +54,6 @@ define( [
 
         this._frameStamp = undefined;
 
-        // texture manager is referenced here because it's associated with gl object
-        // of the gl context intialized with State
-        this._textureManager = Texture.getTextureManager( this._graphicContext );
-
         // we dont use Map because in this use case with a few entries
         // {} is faster
         this._programCommonUniformsCache = {};
@@ -79,10 +75,6 @@ define( [
 
         getCacheUniformsApplyRenderLeaf: function () {
             return this._programCommonUniformsCache;
-        },
-
-        getTextureManager: function () {
-            return this._textureManager;
         },
 
         setGraphicContext: function ( graphicContext ) {

--- a/sources/osg/StateSet.js
+++ b/sources/osg/StateSet.js
@@ -217,6 +217,12 @@ define( [
             for ( var i = 0, j = this.textureAttributeMapList.length; i < j; i++ ) {
                 this.getTextureAttribute( i, 'Texture' ).releaseGLObjects( state );
             }
+            var list = this.getAttributeList();
+                for ( i = 0, j = list.length; i < j; i++ ) {
+                    // Remove only if we have releaseGLObject method. 
+                    if ( list[ i ]._object.releaseGLObjects )
+                        list[ i ]._object.releaseGLObjects( state );
+            }
         },
         _getUniformMap: function () {
             return this.uniforms;

--- a/sources/osg/StateSet.js
+++ b/sources/osg/StateSet.js
@@ -218,10 +218,11 @@ define( [
                 this.getTextureAttribute( i, 'Texture' ).releaseGLObjects( state );
             }
             var list = this.getAttributeList();
-                for ( i = 0, j = list.length; i < j; i++ ) {
-                    // Remove only if we have releaseGLObject method. 
-                    if ( list[ i ]._object.releaseGLObjects )
-                        list[ i ]._object.releaseGLObjects( state );
+            for ( i = 0, j = list.length; i < j; i++ ) {
+                // Remove only if we have releaseGLObject method. 
+                if ( list[ i ]._object.releaseGLObjects ) {
+                    list[ i ]._object.releaseGLObjects( state );
+                }
             }
         },
         _getUniformMap: function () {

--- a/sources/osg/StateSet.js
+++ b/sources/osg/StateSet.js
@@ -212,16 +212,15 @@ define( [
         getShaderGeneratorName: function () {
             return this._shaderGeneratorName;
         },
-        releaseGLObjects: function ( state ) {
-            // TODO: We should release Program/Shader attributes too
+        releaseGLObjects: function () {
             for ( var i = 0, j = this.textureAttributeMapList.length; i < j; i++ ) {
-                this.getTextureAttribute( i, 'Texture' ).releaseGLObjects( state );
+                this.getTextureAttribute( i, 'Texture' ).releaseGLObjects();
             }
             var list = this.getAttributeList();
             for ( i = 0, j = list.length; i < j; i++ ) {
                 // Remove only if we have releaseGLObject method. 
                 if ( list[ i ]._object.releaseGLObjects ) {
-                    list[ i ]._object.releaseGLObjects( state );
+                    list[ i ]._object.releaseGLObjects();
                 }
             }
         },

--- a/sources/osg/Texture.js
+++ b/sources/osg/Texture.js
@@ -5,10 +5,11 @@ define( [
     'osg/StateAttribute',
     'osg/Uniform',
     'osg/Image',
+    'osg/GLObject',
     'osgDB/ReaderParser',
     'osg/Map',
     'osg/TextureManager'
-], function ( Q, Notify, MACROUTILS, StateAttribute, Uniform, Image, ReaderParser, CustomMap, TextureManager ) {
+], function ( Q, Notify, MACROUTILS, StateAttribute, Uniform, Image, GLObject, ReaderParser, CustomMap, TextureManager ) {
 
     'use strict';
 
@@ -40,13 +41,13 @@ define( [
      */
     var Texture = function () {
         StateAttribute.call( this );
+        GLObject.call( this );
         this.setDefaultParameters();
         this._dirtyMipmap = true;
         this._applyTexImage2DCallbacks = [];
         this._textureObject = undefined;
 
         this._textureNull = true;
-        this._gl = undefined;
     };
 
     Texture.UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243;
@@ -110,7 +111,7 @@ define( [
         return value;
     };
 
-    Texture.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( StateAttribute.prototype, {
+    Texture.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( GLObject.prototype, MACROUTILS.objectInherit( StateAttribute.prototype, {
         attributeType: 'Texture',
 
         cloneType: function () {
@@ -191,7 +192,7 @@ define( [
         },
 
         init: function ( state ) {
-            if ( !this._gl ) this._gl = state.getGraphicContext();
+            if ( !this._gl ) this.setGraphicContext( state.getGraphicContext() );
             if ( !this._textureObject ) {
                 this._textureObject = Texture.getTextureManager( this._gl ).generateTextureObject( this._gl,
                     this,
@@ -589,7 +590,7 @@ define( [
                 }
             }
         }
-    } ), 'osg', 'Texture' );
+    } ) ), 'osg', 'Texture' );
 
     MACROUTILS.setTypeID( Texture );
 

--- a/sources/osg/TextureCubeMap.js
+++ b/sources/osg/TextureCubeMap.js
@@ -255,11 +255,10 @@ define( [
 
         apply: function ( state ) {
 
+            var gl = state.getGraphicContext();
             // if need to release the texture
             if ( this._dirtyTextureObject )
-                this.releaseGLObjects( state );
-
-            var gl = state.getGraphicContext();
+                this.releaseGLObjects();
 
             if ( this._textureObject !== undefined && !this.isDirty() ) {
                 this._textureObject.bind( gl );

--- a/sources/osg/TextureManager.js
+++ b/sources/osg/TextureManager.js
@@ -164,13 +164,11 @@ define( [
         },
 
         flushDeletedTextureObjects: function ( gl, availableTime ) {
+            // if no time available don't try to flush objects.
+            if ( availableTime <= 0.0 ) return availableTime;
             var nbTextures = this._orphanedTextureObjects.length;
-
             // Should we use a maxSizeTexturePool value?
             //var size = this.getProfile().getSize();
-
-            // if no time available don't try to flush objects.
-            if ( availableTime <= 0.0 ) return;
             // We need to test if we have time to flush
             var elapsedTime = 0.0;
             var beginTime = Timer.instance().tick();
@@ -182,6 +180,7 @@ define( [
             }
             this._orphanedTextureObjects.splice( 0, i );
             availableTime -= elapsedTime;
+            return availableTime;
             //Notify.info( 'TextureManager: released ' + nbTextures + ' with ' + (nbTextures*size/(1024*1024)) + ' MB' );
         },
 
@@ -266,8 +265,9 @@ define( [
             var key;
             for ( var i = 0, j = Object.keys( this._textureSetMap ).length; i < j && availableTime > 0.0; i++ ) {
                 key = Object.keys( this._textureSetMap )[ i ];
-                this._textureSetMap[ key ].flushDeletedTextureObjects( gl, availableTime );
+                availableTime = this._textureSetMap[ key ].flushDeletedTextureObjects( gl, availableTime );
             }
+            return availableTime;
         },
 
         releaseTextureObject: function ( textureObject ) {

--- a/sources/osg/osg.js
+++ b/sources/osg/osg.js
@@ -21,6 +21,7 @@ define( [
     'osg/FrameBufferObject',
     'osg/FrameStamp',
     'osg/Geometry',
+    'osg/GLObject',
     'osg/Image',
     'osg/ImageStream',
     'osg/KdTree',
@@ -94,6 +95,7 @@ define( [
     FrameBufferObject,
     FrameStamp,
     Geometry,
+    GLObject,
     Image,
     ImageStream,
     KdTree,
@@ -173,6 +175,7 @@ define( [
     osg.FrameBufferObject = FrameBufferObject;
     osg.FrameStamp = FrameStamp;
     osg.Geometry = Geometry;
+    osg.GLObject = GLObject;
     osg.Image = Image;
     osg.ImageStream = ImageStream;
     osg.KdTree = KdTree;

--- a/sources/osgDB/DatabasePager.js
+++ b/sources/osgDB/DatabasePager.js
@@ -57,14 +57,13 @@ define( [
         }
     } );
 
-    var ReleaseVisitor = function ( state ) {
+    var ReleaseVisitor = function () {
         NodeVisitor.call( this, NodeVisitor.TRAVERSE_ALL_CHILDREN );
-        this.state = state;
     };
     ReleaseVisitor.prototype = MACROUTILS.objectInherit( NodeVisitor.prototype, {
         apply: function ( node ) {
             // mark GLResources in nodes to be released
-            node.releaseGLObjects( this.state );
+            node.releaseGLObjects();
             this.traverse( node );
         }
     } );
@@ -321,7 +320,7 @@ define( [
             return defer.promise;
         },
 
-        releaseGLExpiredSubgraphs: function ( state, availableTime ) {
+        releaseGLExpiredSubgraphs: function ( availableTime ) {
 
             if ( availableTime <= 0.0 ) return 0.0;
             // We need to test if we have time to flush
@@ -333,7 +332,7 @@ define( [
                 // If we don't have more time, break the loop.
                 if ( elapsedTime > availableTime ) return;
                 that._childrenToRemoveList.delete( node );
-                node.accept( new ReleaseVisitor( state ) );
+                node.accept( new ReleaseVisitor() );
                 node.removeChildren();
                 node = null;
                 elapsedTime = Timer.instance().deltaS( beginTime, Timer.instance().tick() );

--- a/sources/osgDB/DatabasePager.js
+++ b/sources/osgDB/DatabasePager.js
@@ -57,13 +57,14 @@ define( [
         }
     } );
 
-    var ReleaseVisitor = function ( gl ) {
+    var ReleaseVisitor = function ( state ) {
         NodeVisitor.call( this, NodeVisitor.TRAVERSE_ALL_CHILDREN );
-        this.gl = gl;
+        this.state = state;
     };
     ReleaseVisitor.prototype = MACROUTILS.objectInherit( NodeVisitor.prototype, {
         apply: function ( node ) {
-            node.releaseGLObjects( this.gl );
+            // mark GLResources in nodes to be released
+            node.releaseGLObjects( this.state );
             this.traverse( node );
         }
     } );
@@ -320,7 +321,7 @@ define( [
             return defer.promise;
         },
 
-        releaseGLExpiredSubgraphs: function ( gl, availableTime ) {
+        releaseGLExpiredSubgraphs: function ( state, availableTime ) {
 
             if ( availableTime <= 0.0 ) return 0.0;
             // We need to test if we have time to flush
@@ -332,7 +333,7 @@ define( [
                 // If we don't have more time, break the loop.
                 if ( elapsedTime > availableTime ) return;
                 that._childrenToRemoveList.delete( node );
-                node.accept( new ReleaseVisitor( gl ) );
+                node.accept( new ReleaseVisitor( state ) );
                 node.removeChildren();
                 node = null;
                 elapsedTime = Timer.instance().deltaS( beginTime, Timer.instance().tick() );
@@ -368,10 +369,11 @@ define( [
             var expiredPagedLODVisitor = new ExpirePagedLODVisitor();
 
             this._activePagedLODList.forEach( function ( plod ) {
-                if ( elapsedTime > availableTime ) return;
-                if ( numToPrune < 0 ) return;
+                // Check if we have time, else return 0
+                if ( elapsedTime > availableTime ) return 0.0;
+                if ( numToPrune < 0 ) return availableTime;
                 // See if plod is still active, so we don't have to prune
-                if ( expiryFrame < plod.getFrameNumberOfLastTraversal() ) return;
+                if ( expiryFrame < plod.getFrameNumberOfLastTraversal() ) return availableTime;
                 expiredPagedLODVisitor.removeExpiredChildrenAndFindPagedLODs( plod, expiryTime, expiryFrame, removedChildren );
                 for ( var i = 0; i < expiredPagedLODVisitor._childrenList.length; i++ ) {
                     that._activePagedLODList.delete( expiredPagedLODVisitor._childrenList[ i ] );
@@ -384,7 +386,6 @@ define( [
                 expiredPagedLODVisitor._childrenList.length = 0;
                 removedChildren.length = 0;
                 elapsedTime = Timer.instance().deltaS( beginTime, Timer.instance().tick() );
-
             } );
             availableTime -= elapsedTime;
             return availableTime;

--- a/sources/osgViewer/View.js
+++ b/sources/osgViewer/View.js
@@ -5,6 +5,7 @@ define( [
     'osg/CullFace',
     'osg/Depth',
     'osg/FrameStamp',
+    'osg/FrameBufferObject',
     'osg/Light',
     'osg/Material',
     'osg/Matrix',
@@ -29,6 +30,7 @@ define( [
     CullFace,
     Depth,
     FrameStamp,
+    FrameBufferObject,
     Light,
     Material,
     Matrix,
@@ -285,6 +287,7 @@ define( [
             availableTime = Texture.getTextureManager( gl ).flushDeletedTextureObjects( gl, availableTime );
             availableTime = Program.flushDeletedGLPrograms( gl, availableTime );
             availableTime = Shader.flushDeletedGLShaders( gl, availableTime );
+            availableTime = FrameBufferObject.flushDeletedGLFrameBuffers( gl, availableTime );
         }
 
     };

--- a/sources/osgViewer/View.js
+++ b/sources/osgViewer/View.js
@@ -10,6 +10,8 @@ define( [
     'osg/Node',
     'osg/Options',
     'osg/Texture',
+    'osg/Program',
+    'osg/Shader',
     'osg/Viewport',
     'osg/WebGLCaps',
 
@@ -31,6 +33,8 @@ define( [
     Node,
     Options,
     Texture,
+    Program,
+    Shader,
     Viewport,
     WebGLCaps,
 
@@ -274,7 +278,10 @@ define( [
         // CP: I guess it should move into Scene in something like an ImagePager things ?
         flushDeletedGLObjects: function ( /*currentTime,*/ availableTime ) {
             // Flush all deleted OpenGL objects within the specified availableTime
-            this.getCamera().getRenderer().getState().getTextureManager().flushDeletedTextureObjects( this.getGraphicContext(), availableTime );
+            var gl = this.getGraphicContext();
+            availableTime = Texture.getTextureManager( gl ).flushDeletedTextureObjects( gl, availableTime );
+            availableTime = Program.flushDeletedGLPrograms( gl, availableTime );
+            availableTime = Shader.flushDeletedGLShaders( gl, availableTime );
         }
 
     };

--- a/sources/osgViewer/View.js
+++ b/sources/osgViewer/View.js
@@ -1,5 +1,6 @@
 define( [
     'osg/BlendFunc',
+    'osg/BufferArray',
     'osg/Camera',
     'osg/CullFace',
     'osg/Depth',
@@ -23,6 +24,7 @@ define( [
 
 ], function (
     BlendFunc,
+    BufferArray,
     Camera,
     CullFace,
     Depth,
@@ -275,10 +277,11 @@ define( [
             }
         },
 
-        // CP: I guess it should move into Scene in something like an ImagePager things ?
+        // In OSG this call is done in SceneView
         flushDeletedGLObjects: function ( /*currentTime,*/ availableTime ) {
             // Flush all deleted OpenGL objects within the specified availableTime
             var gl = this.getGraphicContext();
+            availableTime = BufferArray.flushDeletedGLBufferArrays( gl, availableTime );
             availableTime = Texture.getTextureManager( gl ).flushDeletedTextureObjects( gl, availableTime );
             availableTime = Program.flushDeletedGLPrograms( gl, availableTime );
             availableTime = Shader.flushDeletedGLShaders( gl, availableTime );

--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -6,7 +6,7 @@ define( [
     'osg/Timer',
     'osg/UpdateVisitor',
     'osg/Utils',
-
+    'osg/Texture',
     'osgGA/OrbitManipulator',
 
     'osgViewer/CanvasStats',
@@ -15,7 +15,7 @@ define( [
     'osgViewer/webgl-utils',
     'osgViewer/webgl-debug'
 
-], function ( Notify, Matrix, Options, Stats, Timer, UpdateVisitor, MACROUTILS, OrbitManipulator, CanvasStats, EventProxy, View, WebGLUtils, WebGLDebugUtils ) {
+], function ( Notify, Matrix, Options, Stats, Timer, UpdateVisitor, MACROUTILS, Texture, OrbitManipulator, CanvasStats, EventProxy, View, WebGLUtils, WebGLDebugUtils ) {
 
     'use strict';
 
@@ -343,7 +343,7 @@ define( [
             canvasStats.addLayer( '#f0f000', 256,
                 function ( /*t*/) {
                     var fn = this.getFrameStamp().getFrameNumber() - 1;
-                    var stats = this.getCamera().getRenderer().getState().getTextureManager().getStats();
+                    var stats = Texture.getTextureManager( this.getGraphicContext() ).getStats();
                     var value = stats.getAttribute( fn, 'Texture used' );
                     return value / ( 1024 * 1024 );
                 }.bind( this ),
@@ -354,7 +354,7 @@ define( [
             canvasStats.addLayer( '#f00f00', 256,
                 function ( /*t*/) {
                     var fn = this.getFrameStamp().getFrameNumber() - 1;
-                    var stats = this.getCamera().getRenderer().getState().getTextureManager().getStats();
+                    var stats = Texture.getTextureManager( this.getGraphicContext() ).getStats();
                     var value = stats.getAttribute( fn, 'Texture total' );
                     return value / ( 1024 * 1024 );
                 }.bind( this ),
@@ -412,7 +412,7 @@ define( [
             // update the scene
             this.getScene().updateSceneGraph( this._updateVisitor );
             // Remove ExpiredSubgraphs from DatabasePager
-            this.getDatabasePager().releaseGLExpiredSubgraphs( this.getState(), 0.005 );
+            this.getDatabasePager().releaseGLExpiredSubgraphs( 0.005 );
             // In OSG this.is deferred until the draw traversal, to handle multiple contexts
             this.flushDeletedGLObjects( 0.005 );
             var deltaS = Timer.instance().deltaS( startTraversal, Timer.instance().tick() );
@@ -464,7 +464,7 @@ define( [
             this.getViewerStats().setAttribute( frameNumber, 'Frame duration', Timer.instance().deltaS( this._startFrameTick, Timer.instance().tick() ) );
 
             if ( this._canvasStats ) { // update ui stats
-                this.getCamera().getRenderer().getState().getTextureManager().updateStats( frameNumber );
+                Texture.getTextureManager( this.getGraphicContext() ).updateStats( frameNumber );
                 this._canvasStats.update();
             }
         },

--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -412,7 +412,7 @@ define( [
             // update the scene
             this.getScene().updateSceneGraph( this._updateVisitor );
             // Remove ExpiredSubgraphs from DatabasePager
-            this.getDatabasePager().releaseGLExpiredSubgraphs( this.getGraphicContext(), 0.005 );
+            this.getDatabasePager().releaseGLExpiredSubgraphs( this.getState(), 0.005 );
             // In OSG this.is deferred until the draw traversal, to handle multiple contexts
             this.flushDeletedGLObjects( 0.005 );
             var deltaS = Timer.instance().deltaS( startTraversal, Timer.instance().tick() );

--- a/tests/osg/BufferArray.js
+++ b/tests/osg/BufferArray.js
@@ -16,8 +16,6 @@ define( [
 
             ( function () {
                 var gl = mockup.createFakeRenderer();
-                var state = new State( new ShaderGeneratorProxy() );
-                state.setGraphicContext( gl );
                 gl.createBuffer = function () {
                     return {};
                 };
@@ -29,7 +27,7 @@ define( [
                 var b = new BufferArray( BufferArray.ARRAY_BUFFER, content, 3 );
                 b.bind( gl );
                 ok( b._buffer !== undefined, 'Check we created gl buffer' );
-                b.releaseGLObjects( state );
+                b.releaseGLObjects();
                 ok( b._buffer === undefined, 'Check we released gl buffer' );
             } )();
         } );

--- a/tests/osg/BufferArray.js
+++ b/tests/osg/BufferArray.js
@@ -1,8 +1,10 @@
 define( [
     'qunit',
     'tests/mockup/mockup',
-    'osg/BufferArray'
-], function ( QUnit, mockup, BufferArray ) {
+    'osg/BufferArray',
+    'osgShader/ShaderGeneratorProxy',
+    'osg/State'
+], function ( QUnit, mockup, BufferArray, ShaderGeneratorProxy, State ) {
 
     'use strict';
 
@@ -14,6 +16,8 @@ define( [
 
             ( function () {
                 var gl = mockup.createFakeRenderer();
+                var state = new State( new ShaderGeneratorProxy() );
+                state.setGraphicContext( gl );
                 gl.createBuffer = function () {
                     return {};
                 };
@@ -25,7 +29,7 @@ define( [
                 var b = new BufferArray( BufferArray.ARRAY_BUFFER, content, 3 );
                 b.bind( gl );
                 ok( b._buffer !== undefined, 'Check we created gl buffer' );
-                b.releaseGLObjects( gl );
+                b.releaseGLObjects( state );
                 ok( b._buffer === undefined, 'Check we released gl buffer' );
             } )();
         } );


### PR DESCRIPTION
...text. This way we can emulate the behaviour of OSG when releasing textures. 

It is not a complete fix for all the releaseGL stuff, it's only for Textures so DatabasePager frees Texture memory again.  
We can discuss it further, but I think this way we can release other GLObjects with and without state, as OSG does. In OSG a static variable keeps track of GLObjects or each class with respect a contextID.   