### PR TITLE
[#91685744] Fixes Absolute Ref Node above light Node for shadow

### DIFF
--- a/examples/shadowmap/main.js
+++ b/examples/shadowmap/main.js
@@ -1137,8 +1137,9 @@
             this._lightsSource.push( lightSource );
 
             /////////////////////////////
-            // add light to scene
-            group.addChild( lightNode );
+            // add light to shadowedscene
+            this._lightAndShadowScene.addChild( lightNode );
+            //group.addChild( lightNode );
             /////////////////////////////
 
             var lightNodemodel = osg.createAxisGeometry();
@@ -1146,7 +1147,7 @@
             lightNodemodelNode.addChild( lightNodemodel );
             this._debugLights.push( lightNodemodelNode );
             // light debug axis view
-            // totally indepedant scene tree than light
+            // totally independant scene tree than light
             /////////
             group.addChild( lightNodemodelNode );
             ///////////////////

--- a/sources/osg/Light.js
+++ b/sources/osg/Light.js
@@ -305,6 +305,10 @@ define( [
             return this._ground[ 3 ] >= 0.0;
         },
 
+        // matrix is current model view, which can mean:
+        // world (node refAbsolute)
+        // world+camera (camera is refAbsolute)
+        // world+camera+camera+... (camera relative...)
         applyPositionedUniform: function ( matrix /*, state*/ ) {
 
             var uniformMap = this.getOrCreateUniforms();

--- a/sources/osg/RenderStage.js
+++ b/sources/osg/RenderStage.js
@@ -71,6 +71,9 @@ define( [
         getCamera: function () {
             return this.camera;
         },
+        getPositionedAttribute: function () {
+            return this.positionedAttribute;
+        },
         addPreRenderStage: function ( rs, order ) {
             for ( var i = 0, l = this.preRenderList.length; i < l; i++ ) {
                 var render = this.preRenderList[ i ];
@@ -225,7 +228,7 @@ define( [
 
             gl.clear( this.clearMask );
 
-            if ( this.positionedAttribute ) {
+            if ( this.positionedAttribute.length !== 0 ) {
                 this.applyPositionedAttribute( state, this.positionedAttribute );
             }
 


### PR DESCRIPTION
- Add new constraint on shadowing ligh : the light node must be under shadowedScene Node in the hierarchy scene graph