### PR TITLE
Makes vertex shader composition use the shader graph compiler

### DIFF
--- a/examples/shader-generator/CustomCompiler.js
+++ b/examples/shader-generator/CustomCompiler.js
@@ -34,8 +34,14 @@ var CustomCompiler;
             var materialUniforms = this.getOrCreateStateAttributeUniforms( this._material );
 
 
+            // here we gather all Root of the Shader Graph
+            // for the cases where you have multiple output
+            // (output glFragDepth, or
+            // glFragColor[0], glFragColor[1], etc in the MRT case)
+            var roots = [];
+
             // that's the final result of the shader graph
-            var fragColor = factory.getNode( 'FragColor' );
+            var fragColor = factory.getNode( 'glFragColor' );
 
 
             // diffuse color
@@ -129,7 +135,8 @@ var CustomCompiler;
 
             }
 
-            return fragColor;
+            roots.push( fragColor );
+            return roots;
         }
 
     } );

--- a/examples/shader-generator/negatif.js
+++ b/examples/shader-generator/negatif.js
@@ -68,7 +68,7 @@
         },
 
         // call the glsl function with input/output of the node
-        computeFragment: function () {
+        computeShader: function () {
             return osgShader.utils.callFunction( 'negatif', undefined, [
                 this._inputs.enable,
                 this._inputs.color,

--- a/examples/shader-generator/ramp.js
+++ b/examples/shader-generator/ramp.js
@@ -58,7 +58,7 @@
         },
 
         // call the glsl function with input/output of the node
-        computeFragment: function () {
+        computeShader: function () {
             return osgShader.utils.callFunction( 'ramp', undefined, [
                 this._inputs.color,
                 this._outputs.color

--- a/examples/shadow/main.js
+++ b/examples/shadow/main.js
@@ -94,9 +94,6 @@
     function getTextureProjectedShadowShader() {
         var vertexshader = [
             '',
-            '#ifdef GL_ES',
-            'precision highp float;',
-            '#endif',
             'attribute vec3 Vertex;',
             'uniform mat4 ModelViewMatrix;',
             'uniform mat4 ProjectionMatrix;',
@@ -136,9 +133,6 @@
     function getBlurrShader() {
         var vertexshader = [
             '',
-            '#ifdef GL_ES',
-            'precision highp float;',
-            '#endif',
             'attribute vec3 Vertex;',
             'attribute vec2 TexCoord0;',
             'uniform mat4 ModelViewMatrix;',
@@ -158,7 +152,7 @@
             '#endif',
             'uniform sampler2D Texture0;',
             'varying vec2 uv0;',
-            'float shift = 1.0/512.0;',
+            'const float shift = 1.0/512.0;',
             'vec4 getSmoothTexelFilter(vec2 uv) {',
             '  vec4 c = texture2D( Texture0,  uv);',
             '  c += texture2D( Texture0, uv+vec2(0,shift));',
@@ -315,9 +309,6 @@
     function getShadowMapShaderLight() {
         var vertexshader = [
             '',
-            '#ifdef GL_ES',
-            'precision highp float;',
-            '#endif',
             'attribute vec3 Vertex;',
             'uniform mat4 ModelViewMatrix;',
             'uniform mat4 ProjectionMatrix;',
@@ -368,9 +359,6 @@
 
     function getOgreShadowMapShader() {
         var vertexshader = [
-            '#ifdef GL_ES',
-            'precision highp float;',
-            '#endif',
             'attribute vec3 Vertex;',
             'attribute vec3 Normal;',
             'uniform mat4 ModelViewMatrix;',

--- a/sources/osg/Material.js
+++ b/sources/osg/Material.js
@@ -15,7 +15,6 @@ define( [
         this._specular = [ 0.0, 0.0, 0.0, 1.0 ];
         this._emission = [ 0.0, 0.0, 0.0, 1.0 ];
         this._shininess = 12.5;
-        this._shadeless = false;
     };
 
     Material.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( StateAttribute.prototype, {
@@ -95,6 +94,7 @@ define( [
         getShininess: function () {
             return this._shininess;
         },
+
 
 
         setTransparency: function ( a ) {

--- a/sources/osgShader/ShaderProcessor.js
+++ b/sources/osgShader/ShaderProcessor.js
@@ -92,9 +92,9 @@ define( [
             return preShader;
         },
 
-        getShader: function ( shaderName, defines, extensions ) {
+        getShader: function ( shaderName, defines, extensions, type ) {
             var shader = this.getShaderTextPure( shaderName );
-            return this.processShader( shader, defines, extensions );
+            return this.processShader( shader, defines, extensions, type );
         },
 
         // recursively  handle #include external glsl
@@ -156,7 +156,7 @@ define( [
         //  resolving include dependencies
         //  adding defines
         //  adding line instrumenting.
-        processShader: function ( shader, defines, extensions ) {
+        processShader: function ( shader, defines, extensions, type ) {
 
             var includeList = [];
             var preShader = shader;
@@ -193,7 +193,8 @@ define( [
                 prePrend += extensions.join( '\n' ) + '\n';
             }
 
-            if ( this._globalDefaultprecision ) {
+            // vertex shader doesn't need precision, it's highp per default, enforced per spec
+            if ( this._globalDefaultprecision && type !== 'vertex' ) {
                 if ( !this._precisionR.test( postShader ) ) {
                     // use the shaderhighprecision flag at shaderloader start
                     //var highp = gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT);

--- a/sources/osgShader/node/Node.js
+++ b/sources/osgShader/node/Node.js
@@ -29,6 +29,9 @@ define( [
         getID: function () {
             return this._id;
         },
+        getName: function () {
+            return this._name;
+        },
 
         getType: function () {
             return this.type;
@@ -141,7 +144,7 @@ define( [
             return this;
         },
 
-        computeFragment: function () {
+        computeShader: function () {
             return this._text;
         },
 

--- a/sources/osgShader/node/data.js
+++ b/sources/osgShader/node/data.js
@@ -8,6 +8,7 @@ define( [
 
     var sprintf = utils.sprintf;
 
+    // TODO: Add constant, so that we can do setFromNode(constantVar)
     var Variable = function ( type, prefix ) {
         Node.apply( this );
         this._name = 'Variable';
@@ -40,6 +41,16 @@ define( [
         }
     } );
 
+    var Constant = function ( type, prefix ) {
+        Variable.call( this, type, prefix );
+    };
+    Constant.prototype = MACROUTILS.objectInherit( Variable.prototype, {
+
+        declare: function () {
+            return sprintf( 'const %s %s = %s;', [ this._type, this.getVariable(), this._value ] );
+        }
+    } );
+
     var Uniform = function ( type, prefix ) {
         Variable.call( this, type, prefix );
     };
@@ -56,6 +67,21 @@ define( [
 
     } );
 
+    var Attribute = function ( type, prefix ) {
+        Variable.call( this, type, prefix );
+    };
+
+    Attribute.prototype = MACROUTILS.objectInherit( Variable.prototype, {
+
+        declare: function () {
+            return undefined;
+        },
+
+        globalDeclaration: function () {
+            return sprintf( 'attribute %s %s;', [ this._type, this.getVariable() ] );
+        }
+
+    } );
 
 
     var Varying = function ( type, prefix ) {
@@ -70,8 +96,15 @@ define( [
 
         globalDeclaration: function () {
             return sprintf( 'varying %s %s;', [ this._type, this.getVariable() ] );
-        }
+        },
 
+        // bewteen vertex shader and fragmetn shader
+        // we keep varying but not associated
+        reset: function () {
+            this._inputs = [];
+            this._outputs = null;
+            this._text = undefined;
+        }
     } );
 
 
@@ -93,11 +126,24 @@ define( [
 
     } );
 
-
-    var FragColor = function () {
+    // Graph Root Nodes
+    var glFragColor = function () {
         Variable.call( this, 'vec4', 'gl_FragColor' );
     };
-    FragColor.prototype = MACROUTILS.objectInherit( Variable.prototype, {
+    glFragColor.prototype = MACROUTILS.objectInherit( Variable.prototype, {
+
+        outputs: function () { /* do nothing for variable */
+            return this;
+        },
+        getVariable: function () {
+            return this._prefix;
+        }
+    } );
+
+    var glPosition = function () {
+        Variable.call( this, 'vec4', 'gl_Position' );
+    };
+    glPosition.prototype = MACROUTILS.objectInherit( Variable.prototype, {
 
         outputs: function () { /* do nothing for variable */
             return this;
@@ -108,11 +154,27 @@ define( [
     } );
 
 
+    var glPointSize = function () {
+        Variable.call( this, 'vec4', 'gl_PointSize' );
+    };
+    glPointSize.prototype = MACROUTILS.objectInherit( Variable.prototype, {
+
+        outputs: function () { /* do nothing for variable */
+            return this;
+        },
+        getVariable: function () {
+            return this._prefix;
+        }
+    } );
 
     return {
-        FragColor: FragColor,
+        glPointSize: glPointSize,
+        glPosition: glPosition,
+        glFragColor: glFragColor,
         Sampler: Sampler,
         Variable: Variable,
+        Constant: Constant,
+        Attribute: Attribute,
         Varying: Varying,
         Uniform: Uniform
     };

--- a/sources/osgShader/node/functions.js
+++ b/sources/osgShader/node/functions.js
@@ -40,7 +40,7 @@ define( [
             'eyeVector'
         ],
 
-        computeFragment: function () {
+        computeShader: function () {
             return utils.callFunction( 'normalizeNormalAndEyeVector', undefined, [
                 this._inputs.normal,
                 this._inputs.position,
@@ -62,7 +62,7 @@ define( [
         validInputs: [ 'color' /*, 'gamma'*/ ],
         validOuputs: [ 'color' ],
 
-        computeFragment: function () {
+        computeShader: function () {
             return this.computeConversion( 'sRGBToLinear' );
         },
         computeConversion: function ( funcName ) {
@@ -82,7 +82,7 @@ define( [
 
     LinearTosRGB.prototype = MACROUTILS.objectInherit( sRGBToLinear.prototype, {
         type: 'LinearTosRGB',
-        computeFragment: function () {
+        computeShader: function () {
             return this.computeConversion( 'linearTosRGB' );
         }
     } );
@@ -97,7 +97,7 @@ define( [
         validInputs: [ 'normal' ],
         validOuputs: [ 'normal' ],
 
-        computeFragment: function () {
+        computeShader: function () {
             return sprintf( '%s = gl_FrontFacing ? %s : -%s ;', [
                 this._outputs.normal.getVariable(),
                 this._inputs.normal.getVariable(),

--- a/sources/osgShader/node/lights.js
+++ b/sources/osgShader/node/lights.js
@@ -57,7 +57,7 @@ define( [
 
         ],
 
-        computeFragment: function () {
+        computeShader: function () {
 
             return shaderUtils.callFunction(
                 'computePointLightShading',
@@ -126,7 +126,7 @@ define( [
 
         ],
 
-        computeFragment: function () {
+        computeShader: function () {
 
             return shaderUtils.callFunction(
                 'computeSpotLightShading',
@@ -191,7 +191,7 @@ define( [
 
         ],
 
-        computeFragment: function () {
+        computeShader: function () {
 
             return shaderUtils.callFunction(
                 'computeSunLightShading',
@@ -245,7 +245,7 @@ define( [
             'lightNDL'
         ],
 
-        computeFragment: function () {
+        computeShader: function () {
 
             return shaderUtils.callFunction(
                 'computeHemiLightShading',

--- a/sources/osgShader/node/shadows.js
+++ b/sources/osgShader/node/shadows.js
@@ -31,7 +31,7 @@ define( [
         getExtensions: function () {
             return this._shadow.getExtensions();
         },
-        computeFragment: function () {
+        computeShader: function () {
 
 
             // common inputs

--- a/sources/osgShader/node/textures.js
+++ b/sources/osgShader/node/textures.js
@@ -23,7 +23,7 @@ define( [
         validInputs: [ 'sampler', 'uv' ],
         validOutputs: [ 'color' ],
 
-        computeFragment: function () {
+        computeShader: function () {
 
             return utils.callFunction( this.functionName,
                 this._outputs.color, [

--- a/sources/osgShader/nodeFactory.js
+++ b/sources/osgShader/nodeFactory.js
@@ -45,6 +45,10 @@ define( [
 
             var Constructor = this._nodes.get( name );
             if ( !Constructor ) {
+                // Means either:
+                // - the node isn't registered by methods above
+                // - you mistyped the name
+                // - Core Node has changed its Name
                 Notify.warn( 'Node ' + name + ' does not exist' );
                 return undefined;
             }

--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -255,7 +255,7 @@ define( [
             if ( !this._shaderProcessor )
                 this._shaderProcessor = new ShaderProcessor( true ); //
 
-            var vertexshader = this._shaderProcessor.getShader( vs, defines );
+            var vertexshader = this._shaderProcessor.getShader( vs, defines, undefined, 'vertex' );
             var fragmentshader = this._shaderProcessor.getShader( ps, defines );
 
             var program = new Program(

--- a/sources/osgUtil/Composer.js
+++ b/sources/osgUtil/Composer.js
@@ -246,9 +246,6 @@ define( [
 
 
     Composer.Filter.defaultVertexShader = [
-        '#ifdef GL_ES',
-        'precision highp float;',
-        '#endif',
         'attribute vec3 Vertex;',
         'attribute vec2 TexCoord0;',
         'varying vec2 FragTexCoord0;',
@@ -262,9 +259,7 @@ define( [
     ].join( '\n' );
 
     Composer.Filter.defaultFragmentShaderHeader = [
-        '#ifdef GL_ES',
-        'precision highp float;',
-        '#endif',
+        '#ifdef GL_FRAGMENT_PRECISION_HIGH\n precision highp float;\n #else\n precision mediump float;\n#endif',
         'varying vec2 FragTexCoord0;',
         'uniform vec2 RenderSize;',
         'uniform sampler2D Texture0;',
@@ -1106,9 +1101,6 @@ define( [
             }
             var vertexshader = [
                 '',
-                '#ifdef GL_ES',
-                'precision highp float;',
-                '#endif',
                 'attribute vec3 Vertex;',
                 'attribute vec2 TexCoord0;',
                 'varying vec2 FragTexCoord0;',
@@ -1251,9 +1243,6 @@ define( [
             }
             var vertexshader = [
                 '',
-                '#ifdef GL_ES',
-                'precision highp float;',
-                '#endif',
                 'attribute vec3 Vertex;',
                 'attribute vec2 TexCoord0;',
                 'attribute vec3 TexCoord1;',

--- a/tests/osgShader/Compiler.js
+++ b/tests/osgShader/Compiler.js
@@ -78,10 +78,10 @@ define( [
                     value.apply( instance );
                     var t = instance.getType();
 
-                    if ( t && t !== '' ) {
-                        realNodeList.push( t );
-                    } else if ( instance._name === 'Variable' ) {
+                    if ( instance._name === 'Variable' ) {
                         variableNodeList.push( instance );
+                    } else if ( t && t !== '' ) {
+                        realNodeList.push( t );
                     } else {
                         abstractNodeList.push( instance );
                     }


### PR DESCRIPTION
Adds Vertex Shader Graph nodes and compilation
Adds Multiple Root Graph to Shader Graph Compiler (both VS and FS)
Optimizes Vertex Shaders Generation upon data (reducing uneeded vertex attributes and varying usage and computations)
Adds New Operation Nodes : MatrixMultPosition, MatrixMultDirection
Adds News "Root" Nodes: glPosition, glPointSize
Adds New Data Nodes: "Constant"
Adds Alias Nodes: SetFromNode (alias to Add Node but with One input, one output)