### PR TITLE
Reverts back line segment test

### DIFF
--- a/sources/osgUtil/LineSegmentIntersector.js
+++ b/sources/osgUtil/LineSegmentIntersector.js
@@ -38,19 +38,41 @@ define( [
             // Not working if culling disabled ??
             return !node.isCullingActive() || this.intersects( node.getBound() );
         },
-        // Optimized Intersection Segment/Sphere 
-        // From Real-Time Rendering, by Tomas Akenine-Möller, Eric Haines, and Naty Hoffman. Pages 738-741
+        // Intersection Segment/Sphere 
         intersects: ( function () {
-            var l = Vec3.create();
+            var sm = Vec3.create();
+            var se = Vec3.create();
             return function ( bsphere ) {
+                // test for _start inside the bounding sphere
                 if ( !bsphere.valid() ) return false;
-                Vec3.sub( bsphere.center(), this._iStart, l );
-                var l2 = Vec3.length2( l );
-                if ( l2 <= bsphere.radius2() ) return true;
-                var s = Vec3.dot( l, this._iEnd );
-                if ( s < 0.0 ) return false;
-                var m2 = l2 - ( s * s );
-                if ( m2 > bsphere.radius2() ) return false;
+                Vec3.sub( this._iStart, bsphere.center(), sm );
+                var c = Vec3.length2( sm ) - bsphere.radius2();
+                if ( c <= 0.0 ) {
+                    return true;
+                }
+                // solve quadratic equation
+                Vec3.sub( this._iEnd, this._iStart, se );
+                var a = Vec3.length2( se );
+                var b = Vec3.dot( sm, se ) * 2.0;
+                var d = b * b - 4.0 * a * c;
+                // no intersections if d<0
+                if ( d < 0.0 ) {
+                    return false;
+                }
+                // compute two solutions of quadratic equation
+                d = Math.sqrt( d );
+                var div = 0.5 / a;
+                var r1 = ( -b - d ) * div;
+                var r2 = ( -b + d ) * div;
+
+                // return false if both intersections are before the ray start
+                if ( r1 <= 0.0 && r2 <= 0.0 ) {
+                    return false;
+                }
+
+                if ( r1 > 1.0 && r2 > 1.0 ) {
+                    return false;
+                }
                 return true;
             };
         } )(),

--- a/tests/osgUtil/LineSegmentIntersector.js
+++ b/tests/osgUtil/LineSegmentIntersector.js
@@ -4,6 +4,7 @@ define( [
     'osgUtil/IntersectionVisitor',
     'osgUtil/LineSegmentIntersector',
     'osg/KdTreeBuilder',
+    'osg/BoundingSphere',
     'osg/Camera',
     'osg/Viewport',
     'osg/Matrix',
@@ -11,13 +12,54 @@ define( [
     'osg/Shape',
     'osgViewer/View',
     'osgDB/ReaderParser'
-], function ( QUnit, mockup, IntersectionVisitor, LineSegmentIntersector, KdTreeBuilder, Camera, Viewport, Matrix, MatrixTransform, Shape, View, ReaderParser ) {
+], function ( QUnit, mockup, IntersectionVisitor, LineSegmentIntersector, KdTreeBuilder, BoundingSphere, Camera, Viewport, Matrix, MatrixTransform, Shape, View, ReaderParser ) {
 
     'use strict';
 
     return function () {
 
         QUnit.module( 'osgUtil' );
+
+        QUnit.test( 'LineSegmentIntersector simple test', function () {
+            var lsi = new LineSegmentIntersector();
+            var bs = new BoundingSphere();
+            bs.set( [ 4.0, 2.0, 0.0 ], 2.0 );
+
+            // start right on the edge
+            lsi.set( [ 2.0, 2.0, 0.0 ], [ -1.0, 2.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( lsi.intersects( bs ), 'hit success' );
+
+            // end right on edge
+            lsi.set( [ 2.0, 0.0, 0.0 ], [ 4.0, 0.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( lsi.intersects( bs ), 'hit success' );
+
+            // line right on edge
+            lsi.set( [ 2.0, 0.0, 0.0 ], [ 4.0, 0.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( lsi.intersects( bs ), 'hit success' );
+
+            lsi.set( [ 2.0, 0.0, 0.0 ], [ 3.0, 1.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( lsi.intersects( bs ), 'hit success' );
+
+            lsi.set( [ 0.0, 2.0, 0.0 ], [ 1.9, 2.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( !lsi.intersects( bs ), 'hit failed' );
+
+            lsi.set( [ 0.0, 2.0, 0.0 ], [ 2.1, 2.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( lsi.intersects( bs ), 'hit success' );
+
+            lsi.set( [ 5.0, 1.0, 0.0 ], [ 6.0, 0.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( lsi.intersects( bs ), 'hit success' );
+
+            lsi.set( [ 1.0, 1.0, 0.0 ], [ 2.0, 3.0, 0.0 ] );
+            lsi.setCurrentTransformation( Matrix.create() );
+            ok( !lsi.intersects( bs ), 'hit failed' );
+        } );
 
         QUnit.test( 'LineSegmentIntersector without 2 branches', function () {
 


### PR DESCRIPTION
Reverts the old "segment/sphere" intersection test.

I guess it can be still be optimized @jtorresfabra.
Here's an alternative (I don't know if it's faster though) :

```
intersects: ( function () {
    var l = Vec3.create();
    var dir = Vec3.create();
    return function ( bsphere ) {
        if ( !bsphere.valid() ) return false;
        var center = bsphere.center();
        var r2 = bsphere.radius2();

        Vec3.sub( center, this._iStart, l );
        Vec3.sub( this._iEnd, this._iStart, dir );

        var t = Vec3.dot( l, dir ) / Vec3.length2( dir );
        if ( t <= 0.0 ) return Vec3.length2( l ) <= r2;
        if ( t >= 1.0 ) return Vec3.length2( Vec3.sub( center, this._iEnd, l ) ) <= r2;

        Vec3.mult( dir, t, dir );
        return Vec3.distance2( l, dir ) <= r2;
    };
} )(),
```