### PR TITLE
Removes Camera.getNearFar() and setNearFar

### DIFF
--- a/sources/osg/Camera.js
+++ b/sources/osg/Camera.js
@@ -121,17 +121,6 @@ define( [
                 zNear, zFar ) {
                 Matrix.makeOrtho( left, right, bottom, top, zNear, zFar, this.getProjectionMatrix() );
             },
-            setNearFar: function ( zNear, zFar ) {
-                this._near = zNear;
-                this._far = zFar;
-            },
-            getNear: function () {
-                return this._near;
-            },
-            getFar: function () {
-                return this._far;
-            },
-
             isRenderToTextureCamera: function () {
                 return Object.keys( this._attachments ).length > 0;
             },

--- a/sources/osg/CullVisitor.js
+++ b/sources/osg/CullVisitor.js
@@ -339,14 +339,6 @@ define( [
             this.popViewport();
         }
 
-
-        // store complete frustum
-        // if we computed near far
-        // for any other usage
-        // (ie: shadow frustums intersection)
-        if ( camera.getComputeNearFar() ) {
-            camera.setNearFar( this._computedNear, this._computedFar );
-        }
         // restore previous state of the camera
         this.setCullSettings( previousCullsettings );
         this._computedNear = previousZnear;

--- a/sources/osgViewer/Renderer.js
+++ b/sources/osgViewer/Renderer.js
@@ -169,12 +169,8 @@ define( [
                 this._cullVisitor.handleCullCallbacksAndTraverse( camera );
 
                 // fix projection matrix if camera has near/far auto compute
-                this._cullVisitor.popModelViewMatrix();
-                this._cullVisitor.popProjectionMatrix();
+                this._cullVisitor.popCameraModelViewProjectionMatrix( camera );
 
-
-                // store complete frustum
-                camera.setNearFar( this._cullVisitor._computedNear, this._cullVisitor._computedFar );
                 // Update near/far in the camera projection matrix
                 Matrix.clampProjectionMatrix( camera.getProjectionMatrix(), this._cullVisitor._computedNear, this._cullVisitor._computedFar, this._cullVisitor._nearFarRatio );
                 // restore previous state of the camera


### PR DESCRIPTION
- Modifies frustum culling demo to follow the new convention
- Modifies Renderer so that it does call "CullVisitor::popCameraModelViewProjectionMatrix" on Main camera follows same code and can also be hooked
