### PR TITLE
Fixes cloned shadow attribute overwriting uniforms 

### DIFF
--- a/sources/osgShadow/ShadowReceiveAttribute.js
+++ b/sources/osgShadow/ShadowReceiveAttribute.js
@@ -284,6 +284,9 @@ define( [
 
         apply: function ( /*state*/) {
 
+            if ( !this._enable )
+                return;
+
             var uniformMap = this.getOrCreateUniforms();
 
             uniformMap.bias.set( this._bias );


### PR DESCRIPTION
Other shadow attributes might get wrong uniform values, as they were using the same key index for the uniform cache