### PR TITLE
Adds webpack loader to strip debug code from build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,6 +99,7 @@ var gruntTasks = {};
 ( function () {
 
     var webpack = require( 'webpack' );
+    // var ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 
     var targets = {
         build: {
@@ -106,7 +107,24 @@ var gruntTasks = {};
                 OSG: [ './sources/OSG.js' ],
                 tests: [ './tests/tests.js' ]
             },
-            devtool: 'source-map'
+            devtool: 'source-map',
+
+            module: {
+                loaders: [ {
+                    test: /\.js$/,
+                    loader: 'webpack-strip-block'
+                } ]
+            }
+
+        },
+
+        builddebug: {
+            entry: {
+                OSG: [ './sources/OSG.js' ],
+                tests: [ './tests/tests.js' ]
+            },
+            devtool: 'eval-source-map'
+
         },
 
         buildrelease: {
@@ -118,6 +136,9 @@ var gruntTasks = {};
                 library: 'OSG'
             },
 
+            loaders: [
+                { test: /\.js$/, loader : 'webpack-strip-block' }
+            ],
             // additional plugins for this specific mode
             plugins: [
                 new webpack.optimize.UglifyJsPlugin( {
@@ -139,6 +160,7 @@ var gruntTasks = {};
         options: webpackConfig,
         build: targets.build,
         buildrelease: targets.buildrelease,
+        builddebug: targets.builddebug,
         docs: targets.docs,
         watch: {
             entry: targets.build.entry,
@@ -545,6 +567,7 @@ module.exports = function ( grunt ) {
 
     grunt.registerTask( 'build', [ 'copyto', 'webpack:build' ] );
     grunt.registerTask( 'build-release', [ 'copyto', 'webpack:buildrelease' ] );
+    grunt.registerTask( 'build-debug', [ 'copyto', 'webpack:builddebug' ] );
 
     grunt.registerTask( 'default', [ 'check', 'build' ] );
     grunt.registerTask( 'serve', [ 'build', 'connect:dist:keepalive' ] );

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "url": "git@github.com:cedricpinson/osgjs.git"
   },
   "description": "OpenSceneGraph implementation in javascript",
-  "license": "LGPL V3+ (https://spdx.org/licenses/LGPL-3.0+)",
-  "author": "Cedric Pinson <trigrou@gmail.com> (http://cedricpinson.com)",
+  "license": "MIT",
+  "author": "Cedric Pinson <trigrou@trigrou.com> (http://cedricpinson.com)",
   "version": "0.2.3",
   "contributors": [
     "Tuan.kuranes <tuan.kuranes@gmail.com>",
@@ -41,6 +41,7 @@
     "grunt-docco": "~0.3.2",
     "grunt-jsbeautifier": "^0.2.10",
     "grunt-plato": "~0.2.1",
-    "grunt-release": "^0.10.0"
+    "grunt-release": "^0.10.0",
+    "webpack-strip-block": "0.0.1"
   }
 }

--- a/sources/osg/Notify.js
+++ b/sources/osg/Notify.js
@@ -91,14 +91,14 @@ define( [], function () {
         };
 
         var assert = function ( test, str ) {
-            if ( this.console !== undefined ) {
-                this.console.assert( test, str, getStackTrace() );
+            if ( this.console !== undefined && !test ) {
+                this.console.assert( test, str );
             }
         };
 
         var dummy = function () {};
 
-        Notify.assert = dummy;
+        Notify.assert = assert;
         Notify.debug = dummy;
         Notify.info = dummy;
         Notify.log = Notify.notice = dummy;
@@ -107,7 +107,6 @@ define( [], function () {
 
         if ( level <= Notify.DEBUG ) {
             Notify.debug = debug;
-            Notify.assert = assert;
         }
         if ( level <= Notify.INFO ) {
             Notify.info = info;

--- a/sources/osg/State.js
+++ b/sources/osg/State.js
@@ -432,6 +432,11 @@ define( [
                     attribute = attributeStack.back().object;
                 }
 
+                /* develblock:start */
+                Notify.assert( key === attribute.getTypeMember(), 'State:applyAttributeMap attribute key ' + key + ' !== ' + attribute.getTypeMember() );
+                /* develblock:end */
+
+
                 if ( attributeStack.lastApplied !== attribute ) {
 
                     if ( attribute.apply )


### PR DESCRIPTION
Now code between
```
 /* develblock:start */
 your code
 /* develblock:end */
```

will be strip from builds except in 'grunt build-debug'