### PR TITLE
Makes mandatory to give a lightsource to shadowmap ctor 

### DIFF
--- a/examples/shadowmap/main.js
+++ b/examples/shadowmap/main.js
@@ -1169,7 +1169,7 @@
 
             // need to set lightSource rather than light pos
             // as there is no link in Light to get current Matrix.
-            shadowSettings.setLightSource( lightSource );
+            shadowSettings.setLight( light );
             ///////////////////////////////
 
             this._shadowSettings.push( shadowSettings );

--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -667,14 +667,15 @@ define( [
             // if none, no shadow, hop we go.
             // TODO: harder Link shadowTexture and shadowAttribute ?
             // TODO: multi shadow textures for 1 light
+            var lightNum = light.getLightNumber();
             for ( k = 0; k < this._shadows.length; k++ ) {
                 shadow = this._shadows[ k ];
-                if ( shadow.getLight() !== light ) continue;
+                if ( shadow.getLightNumber() !== lightNum ) continue;
 
                 lightIndex = k;
                 for ( var p = 0; p < this._shadowsTextures.length; p++ ) {
                     shadowTexture = this._shadowsTextures[ p ];
-                    if ( shadowTexture && shadowTexture.getLightUnit() === light.getLightNumber() ) {
+                    if ( shadowTexture && shadowTexture.getLightUnit() === lightNum ) {
                         shadowTextures[ p ] = shadowTexture;
                         hasShadows = true;
                     }

--- a/sources/osgShadow/ShadowReceiveAttribute.js
+++ b/sources/osgShadow/ShadowReceiveAttribute.js
@@ -17,25 +17,13 @@ define( [
      * @class ShadowReceiveAttribute
      * @inherits StateAttribute
      */
-    var ShadowReceiveAttribute = function ( lightNumber, disable ) {
+    var ShadowReceiveAttribute = function ( lightNum, disable ) {
         StateAttribute.call( this );
 
+        this._lightNumber = lightNum;
 
-        //this._lightNumber // (might be broken by light reordering change) // yeah agree
-
-        // just in case
-        // the object in case of change in ordering ?
-        // need to be able to link in compiler the light uniforms as we use light uniforms in shadow shader code
-        // well it's not supposed to be a problem, but yeah the ordering is an issue, so maybe it's better to link to
-        // the light attribute, in this case we dont need anymore the _lightNumber
-        // but re ordering light seems to not be a good practice in osg, it's still a risk
-        this._light = undefined;
-        // that could be more generic to have the unit instead of the object
 
         // see shadowSettings.js header for shadow algo param explanations
-
-        this._lightNumber = lightNumber !== undefined ? lightNumber : 0;
-
         // hash change var
         this._algoType = 'NONE';
 
@@ -130,12 +118,9 @@ define( [
         getPrecision: function () {
             return this._precision;
         },
-        getLight: function () {
-            return this._light;
-        },
-        setLight: function ( light ) {
-            this._light = light;
-            this._lightNumber = light.getLightNumber();
+
+        setLightNumber: function ( lightNum ) {
+            this._lightNumber = lightNum;
             this.dirty();
         },
 

--- a/sources/osgShadow/ShadowSettings.js
+++ b/sources/osgShadow/ShadowSettings.js
@@ -104,11 +104,11 @@ define( [
             return this.castsShadowBoundsTraversalMask;
         },
 
-        setLightSource: function ( lightSource ) {
-            this.lightSource = lightSource;
+        setLight: function ( light ) {
+            this.light = light;
         },
-        getLightSource: function () {
-            return this.lightSource;
+        getLight: function () {
+            return this.light;
         },
 
         setTextureSize: function ( textureSize ) {

--- a/tests/osgShader/Compiler.js
+++ b/tests/osgShader/Compiler.js
@@ -21,11 +21,8 @@ define( [
             ( function () {
 
                 var light = new Light( 1 );
-                var lightSource = new LightSource();
-                lightSource.setLight( light );
-                var shadowReceiveAttribute = new ShadowReceiveAttribute();
+                var shadowReceiveAttribute = new ShadowReceiveAttribute( light.getLightNumber() );
                 var shadowTexture = new ShadowTexture();
-                shadowReceiveAttribute.setLight( light );
                 shadowTexture.setLightUnit( light.getLightNumber() );
 
                 var material = new Material();

--- a/tests/osgShadow/ShadowMap.js
+++ b/tests/osgShadow/ShadowMap.js
@@ -5,8 +5,9 @@ define( [
     'osg/LightSource',
     'osg/Matrix',
     'osg/Vec3',
-    'osgShadow/ShadowMap'
-], function ( QUnit, BoundingBox, Light, LightSource, Matrix, Vec3, ShadowMap ) {
+    'osgShadow/ShadowMap',
+    'osgShadow/ShadowSettings'
+], function ( QUnit, BoundingBox, Light, LightSource, Matrix, Vec3, ShadowMap, ShadowSettings ) {
 
     'use strict';
 
@@ -24,7 +25,10 @@ define( [
 
         QUnit.test( 'ShadowedMap', function () {
 
-            var shadowMap = new ShadowMap();
+            var shadowSettings = new ShadowSettings();
+            shadowSettings.light = new Light();
+
+            var shadowMap = new ShadowMap( shadowSettings );
             var frustumBound = new BoundingBox();
             var resultView, resultProj, resultNearFar;
 


### PR DESCRIPTION
So that shadowreceiveattribute ctor has a light number at creation.
Otherwise shadowreceiveattribute  may  be cloned without any "light" and then if using multiple shadowreceiveattribute, you'll have mutiple cloned default shadowreceiveattribute with typeMember !== key in the State.js AttributeMap

/!\ Breaking Change for all shadowmap user (lightSource of settings given to ShadowMap need a lightSource )