### PR TITLE
Fixes wrong initial compiler flags making unessecary varyings detected

### DIFF
--- a/sources/osgShader/node/Node.js
+++ b/sources/osgShader/node/Node.js
@@ -38,9 +38,7 @@ define( [
         },
 
         toString: function () {
-            return this._name +
-                ' : { inputs: ' + ( this._inputs ? this._inputs.toString() : '' ) + ' },' +
-                'outputs: { ' + ( this._outputs ? this._outputs.toString() : '' ) + ' } ';
+            return 'name : ' + this._name + ', type : ' + this.type;
         },
 
         getInputs: function () {


### PR DESCRIPTION
Fixes wrong initial compiler flags making unessecary varyings detected
Fixes unlighted material wrong initial compiler flags making unessecary uniforms detected
by new Compiler
Fixes customVertexShader usage incorrectly making compiler check on varyings
Adds Better warning/error logs on varyings (name + type)