### PR TITLE
Improves manipulators

### DIFF
--- a/sources/osgGA/FirstPersonManipulator.js
+++ b/sources/osgGA/FirstPersonManipulator.js
@@ -5,10 +5,11 @@ define( [
     'osg/Matrix',
     'osg/Vec2',
     'osg/Vec3',
-    'osgGA/FirstPersonManipulatorMouseKeyboardController',
+    'osgGA/FirstPersonManipulatorDeviceOrientationController',
+    'osgGA/FirstPersonManipulatorHammerController',
     'osgGA/FirstPersonManipulatorOculusController',
-    'osgGA/FirstPersonManipulatorDeviceOrientationController'
-], function ( MACROUTILS, Manipulator, OrbitManipulator, Matrix, Vec2, Vec3, FirstPersonManipulatorMouseKeyboardController, FirstPersonManipulatorOculusController, FirstPersonManipulatorDeviceOrientationController ) {
+    'osgGA/FirstPersonManipulatorStandardMouseKeyboardController'
+], function ( MACROUTILS, Manipulator, OrbitManipulator, Matrix, Vec2, Vec3, FirstPersonManipulatorDeviceOrientationController, FirstPersonManipulatorHammerController, FirstPersonManipulatorOculusController, FirstPersonManipulatorStandardMouseKeyboardController ) {
 
     'use strict';
 
@@ -27,8 +28,8 @@ define( [
         this.init();
     };
 
-    FirstPersonManipulator.AvailableControllerList = [ 'StandardMouseKeyboard', 'Oculus', 'DeviceOrientation' ];
-    FirstPersonManipulator.ControllerList = [ 'StandardMouseKeyboard', 'Oculus', 'DeviceOrientation' ];
+    FirstPersonManipulator.AvailableControllerList = [ 'StandardMouseKeyboard', 'Oculus', 'DeviceOrientation', 'Hammer' ];
+    FirstPersonManipulator.ControllerList = [ 'StandardMouseKeyboard', 'Oculus', 'DeviceOrientation', 'Hammer' ];
 
     /** @lends FirstPersonManipulator.prototype */
     FirstPersonManipulator.prototype = MACROUTILS.objectInherit( Manipulator.prototype, {
@@ -36,9 +37,9 @@ define( [
             var bs = this.getHomeBound( useBoundingBox );
             if ( !bs ) return;
 
-            this._radius = this.getHomeDistance( bs );
+            this._distance = this.getHomeDistance( bs );
             var cen = bs.center();
-            Vec3.mult( this._direction, -this._radius, this._eye );
+            Vec3.mult( this._direction, -this._distance, this._eye );
             Vec3.add( cen, this._eye, this._eye );
             this.setTarget( cen );
         },
@@ -50,6 +51,11 @@ define( [
             this._forward = new OrbitManipulator.Interpolator( 1 );
             this._side = new OrbitManipulator.Interpolator( 1 );
             this._lookPosition = new OrbitManipulator.Interpolator( 2 );
+
+            // direct pan interpolator (not based on auto-move)
+            this._pan = new OrbitManipulator.Interpolator( 2 );
+            this._zoom = new OrbitManipulator.Interpolator( 1 );
+
             this._stepFactor = 1.0; // meaning radius*stepFactor to move
             this._target = [ 0.0, 0.0, 0.0 ];
             this._angleVertical = 0.0;
@@ -119,8 +125,18 @@ define( [
         getSideInterpolator: function () {
             return this._side;
         },
-        getFowardInterpolator: function () {
+        getForwardInterpolator: function () {
             return this._forward;
+        },
+        getPanInterpolator: function () {
+            return this._pan;
+        },
+        getZoomInterpolator: function () {
+            return this._zoom;
+        },
+        getRotateInterpolator: function () {
+            // for compatibility with orbit hammer controllers
+            return this._lookPosition;
         },
 
         computeRotation: ( function () {
@@ -175,17 +191,28 @@ define( [
 
                 this.computeRotation( -delta[ 0 ] * 0.5, -delta[ 1 ] * 0.5 );
 
+                // TDOO why check with epsilon ?
+                var factor = this._distance < 1e-3 ? 1e-3 : this._distance;
+
+                // see comment in orbitManipulator for fov modulation speed
+                var proj = this._camera.getProjectionMatrix();
+                var vFov = proj[ 15 ] === 1 ? 1.0 : 2.00 / proj[ 5 ];
+
+                // time based displacement vector
                 vec[ 0 ] = this._forward.getCurrent()[ 0 ];
                 vec[ 1 ] = this._side.getCurrent()[ 0 ];
-                if ( Vec2.length( vec ) > 1.0 ) {
-                    Vec2.normalize( vec, vec );
-                }
-                var factor = this._distance;
-                if ( this._distance < 1e-3 ) {
-                    factor = 1.0;
-                }
-                this.moveForward( vec[ 0 ] * factor * this._stepFactor * dt );
-                this.strafe( vec[ 1 ] * factor * this._stepFactor * dt );
+                if ( Vec2.length( vec ) > 1.0 ) Vec2.normalize( vec, vec );
+
+                // direct displacement vectors
+                var pan = this._pan.update();
+                var zoom = this._zoom.update();
+
+                var timeFactor = this._stepFactor * factor * vFov * dt;
+                var directFactor = this._stepFactor * factor * vFov * 0.002;
+
+                this.moveForward( vec[ 0 ] * timeFactor - zoom[ 0 ] * directFactor * 20.0 );
+                this.strafe( vec[ 1 ] * timeFactor - pan[ 0 ] * directFactor );
+                this.strafeVertical( -pan[ 1 ] * directFactor );
 
                 Vec3.add( this._eye, this._direction, this._target );
 
@@ -213,20 +240,22 @@ define( [
                 Vec3.mult( tmp, distance, tmp );
                 Vec3.add( this._eye, tmp, this._eye );
             };
-        } )()
+        } )(),
+
+        strafeVertical: ( function () {
+            var tmp = [ 0.0, 0.0, 0.0 ];
+            return function ( distance ) {
+                Vec3.normalize( this._up, tmp );
+                Vec3.mult( tmp, distance, tmp );
+                Vec3.add( this._eye, tmp, this._eye );
+            };
+        } )(),
     } );
 
-    ( function ( module ) {
-        module.StandardMouseKeyboard = FirstPersonManipulatorMouseKeyboardController;
-    } )( FirstPersonManipulator );
-
-    ( function ( module ) {
-        module.Oculus = FirstPersonManipulatorOculusController;
-    } )( FirstPersonManipulator );
-
-    ( function ( module ) {
-        module.DeviceOrientation = FirstPersonManipulatorDeviceOrientationController;
-    } )( FirstPersonManipulator );
+    FirstPersonManipulator.DeviceOrientation = FirstPersonManipulatorDeviceOrientationController;
+    FirstPersonManipulator.Hammer = FirstPersonManipulatorHammerController;
+    FirstPersonManipulator.Oculus = FirstPersonManipulatorOculusController;
+    FirstPersonManipulator.StandardMouseKeyboard = FirstPersonManipulatorStandardMouseKeyboardController;
 
     return FirstPersonManipulator;
 } );

--- a/sources/osgGA/FirstPersonManipulatorHammerController.js
+++ b/sources/osgGA/FirstPersonManipulatorHammerController.js
@@ -1,0 +1,9 @@
+define( [
+    'osgGA/OrbitManipulatorHammerController',
+], function ( OrbitManipulatorHammerController ) {
+
+    'use strict';
+
+    return OrbitManipulatorHammerController;
+
+} );

--- a/sources/osgGA/FirstPersonManipulatorStandardMouseKeyboardController.js
+++ b/sources/osgGA/FirstPersonManipulatorStandardMouseKeyboardController.js
@@ -1,11 +1,13 @@
 define( [], function () {
 
-    var FirstPersonManipulatorMouseKeyboardController = function ( manipulator ) {
+    'use strict';
+
+    var FirstPersonManipulatorStandardMouseKeyboardController = function ( manipulator ) {
         this._manipulator = manipulator;
         this.init();
     };
 
-    FirstPersonManipulatorMouseKeyboardController.prototype = {
+    FirstPersonManipulatorStandardMouseKeyboardController.prototype = {
         init: function () {
             this.releaseButton();
             this._delay = 0.15;
@@ -61,13 +63,13 @@ define( [], function () {
                 manipulator.computeHomePosition();
                 event.preventDefault();
             } else if ( event.keyCode === 87 || event.keyCode === 90 || event.keyCode === 38 ) { // w/z/up
-                manipulator.getFowardInterpolator().setDelay( this._delay );
-                manipulator.getFowardInterpolator().setTarget( 1 );
+                manipulator.getForwardInterpolator().setDelay( this._delay );
+                manipulator.getForwardInterpolator().setTarget( 1 );
                 event.preventDefault();
                 return false;
             } else if ( event.keyCode === 83 || event.keyCode === 40 ) { // S/down
-                manipulator.getFowardInterpolator().setDelay( this._delay );
-                manipulator.getFowardInterpolator().setTarget( -1 );
+                manipulator.getForwardInterpolator().setDelay( this._delay );
+                manipulator.getForwardInterpolator().setTarget( -1 );
                 event.preventDefault();
                 return false;
             } else if ( event.keyCode === 68 || event.keyCode === 39 ) { // D/right
@@ -88,8 +90,8 @@ define( [], function () {
             var manipulator = this._manipulator;
             if ( event.keyCode === 87 || event.keyCode === 90 || event.keyCode === 38 || // w/z/up
                 event.keyCode === 83 || event.keyCode === 40 ) { // S/down
-                manipulator.getFowardInterpolator().setDelay( this._delay );
-                manipulator.getFowardInterpolator().setTarget( 0 );
+                manipulator.getForwardInterpolator().setDelay( this._delay );
+                manipulator.getForwardInterpolator().setTarget( 0 );
                 return false;
             } else if ( event.keyCode === 68 || event.keyCode === 39 || // D/right
                 event.keyCode === 65 || event.keyCode === 81 || event.keyCode === 37 ) { // a/q/left
@@ -102,5 +104,5 @@ define( [], function () {
 
     };
 
-    return FirstPersonManipulatorMouseKeyboardController;
+    return FirstPersonManipulatorStandardMouseKeyboardController;
 } );

--- a/sources/osgGA/OrbitManipulator.js
+++ b/sources/osgGA/OrbitManipulator.js
@@ -3,14 +3,13 @@ define( [
     'osg/Vec3',
     'osg/Matrix',
     'osgGA/Manipulator',
-    'osgGA/OrbitManipulatorLeapMotionController',
-    'osgGA/OrbitManipulatorMouseKeyboardController',
-    'osgGA/OrbitManipulatorHammerController',
-    'osgGA/OrbitManipulatorGamePadController',
     'osgGA/OrbitManipulatorDeviceOrientationController',
-    'osgGA/OrbitManipulatorOculusController',
-
-], function ( MACROUTILS, Vec3, Matrix, Manipulator, OrbitManipulatorLeapMotionController, OrbitManipulatorMouseKeyboardController, OrbitManipulatorHammerController, OrbitManipulatorGamePadController, OrbitManipulatorDeviceOrientationController, OrbitManipulatorOculusController ) {
+    'osgGA/OrbitManipulatorGamePadController',
+    'osgGA/OrbitManipulatorHammerController',
+    'osgGA/OrbitManipulatorLeapMotionController',
+    'osgGA/OrbitManipulatorStandardMouseKeyboardController',
+    'osgGA/OrbitManipulatorOculusController'
+], function ( MACROUTILS, Vec3, Matrix, Manipulator, OrbitManipulatorDeviceOrientationController, OrbitManipulatorGamePadController, OrbitManipulatorHammerController, OrbitManipulatorLeapMotionController, OrbitManipulatorStandardMouseKeyboardController, OrbitManipulatorOculusController ) {
 
     'use strict';
 
@@ -403,29 +402,12 @@ define( [
         } )()
     } );
 
-    ( function ( module ) {
-        module.LeapMotion = OrbitManipulatorLeapMotionController;
-    } )( OrbitManipulator );
-
-    ( function ( module ) {
-        module.StandardMouseKeyboard = OrbitManipulatorMouseKeyboardController;
-    } )( OrbitManipulator );
-
-    ( function ( module ) {
-        module.Hammer = OrbitManipulatorHammerController;
-    } )( OrbitManipulator );
-
-    ( function ( module ) {
-        module.GamePad = OrbitManipulatorGamePadController;
-    } )( OrbitManipulator );
-
-    ( function ( module ) {
-        module.DeviceOrientation = OrbitManipulatorDeviceOrientationController;
-    } )( OrbitManipulator );
-
-    ( function ( module ) {
-        module.Oculus = OrbitManipulatorOculusController;
-    } )( OrbitManipulator );
+    OrbitManipulator.DeviceOrientation = OrbitManipulatorDeviceOrientationController;
+    OrbitManipulator.GamePad = OrbitManipulatorGamePadController;
+    OrbitManipulator.Hammer = OrbitManipulatorHammerController;
+    OrbitManipulator.LeapMotion = OrbitManipulatorLeapMotionController;
+    OrbitManipulator.Oculus = OrbitManipulatorOculusController;
+    OrbitManipulator.StandardMouseKeyboard = OrbitManipulatorStandardMouseKeyboardController;
 
     return OrbitManipulator;
 } );

--- a/sources/osgGA/OrbitManipulatorHammerController.js
+++ b/sources/osgGA/OrbitManipulatorHammerController.js
@@ -18,6 +18,7 @@ define( [
             this._rotateFactorY = -this._rotateFactorX;
             this._zoomFactor = 5.0;
 
+            this._lastScale = 0;
             this._nbPointerLast = 0; // to check if we the number of pointers has changed
             this._delay = 0.15;
         },
@@ -101,7 +102,6 @@ define( [
                 Notify.debug( 'drag end, ' + dragCB( gesture ) );
             };
 
-            var toucheScale;
             this._cbPinchStart = function ( event ) {
                 var manipulator = self._manipulator;
                 if ( !manipulator || event.pointerType === 'mouse' ) {
@@ -110,9 +110,9 @@ define( [
                 self._transformStarted = true;
                 var gesture = event;
 
-                toucheScale = gesture.scale;
+                self._lastScale = gesture.scale;
                 manipulator.getZoomInterpolator().reset();
-                manipulator.getZoomInterpolator().set( toucheScale );
+                manipulator.getZoomInterpolator().set( self._lastScale );
                 event.preventDefault();
                 Notify.debug( 'zoom start, ' + dragCB( gesture ) );
             };
@@ -131,10 +131,12 @@ define( [
                     return;
                 }
                 var gesture = event;
-                var scale = ( gesture.scale - toucheScale ) * self._zoomFactor;
-                toucheScale = gesture.scale;
-                var target = manipulator.getZoomInterpolator().getTarget()[ 0 ];
-                manipulator.getZoomInterpolator().setTarget( target - scale );
+                var scale = ( gesture.scale - self._lastScale ) * self._zoomFactor;
+                self._lastScale = gesture.scale;
+
+                var target = manipulator.getZoomInterpolator().getTarget()[ 0 ] - scale;
+                // make the dezoom faster
+                manipulator.getZoomInterpolator().setTarget( target > 0.0 ? target * 4.0 : target );
                 Notify.debug( 'zoom, ' + dragCB( gesture ) );
             };
 

--- a/sources/osgGA/OrbitManipulatorHammerController.js
+++ b/sources/osgGA/OrbitManipulatorHammerController.js
@@ -18,7 +18,7 @@ define( [
             this._rotateFactorY = -this._rotateFactorX;
             this._zoomFactor = 5.0;
 
-            this._pan = false;
+            this._nbPointerLast = 0; // to check if we the number of pointers has changed
             this._delay = 0.15;
         },
         setEventProxy: function ( proxy ) {
@@ -54,12 +54,10 @@ define( [
                     return;
                 }
                 var gesture = event;
-                if ( computeTouches( gesture ) === 2 ) {
-                    self._pan = true;
-                }
-
                 self._dragStarted = true;
-                if ( self._pan ) {
+                self._nbPointerLast = computeTouches( gesture );
+
+                if ( self._nbPointerLast === 2 ) {
                     manipulator.getPanInterpolator().reset();
                     manipulator.getPanInterpolator().set( event.center.x * self._panFactorX, event.center.y * self._panFactorY );
                 } else {
@@ -75,7 +73,15 @@ define( [
                     return;
                 }
                 var gesture = event;
-                if ( self._pan ) {
+                var nbPointers = computeTouches( gesture );
+                // prevent sudden big changes in the event.center variables
+                if ( self._nbPointerLast !== nbPointers ) {
+                    if ( nbPointers === 2 ) manipulator.getPanInterpolator().reset();
+                    else manipulator.getRotateInterpolator().reset();
+                    self._nbPointerLast = nbPointers;
+                }
+
+                if ( nbPointers === 2 ) {
                     manipulator.getPanInterpolator().setTarget( event.center.x * self._panFactorX, event.center.y * self._panFactorY );
                     Notify.debug( 'pan, ' + dragCB( gesture ) );
                 } else {
@@ -92,7 +98,6 @@ define( [
                 }
                 self._dragStarted = false;
                 var gesture = event;
-                self._pan = false;
                 Notify.debug( 'drag end, ' + dragCB( gesture ) );
             };
 

--- a/sources/osgGA/OrbitManipulatorStandardMouseKeyboardController.js
+++ b/sources/osgGA/OrbitManipulatorStandardMouseKeyboardController.js
@@ -2,12 +2,14 @@ define( [
     'osgGA/OrbitManipulatorEnums'
 ], function ( OrbitManipulatorEnums ) {
 
-    var OrbitManipulatorMouseKeyboardController = function ( manipulator ) {
+    'use strict';
+
+    var OrbitManipulatorStandardMouseKeyboardController = function ( manipulator ) {
         this._manipulator = manipulator;
         this.init();
     };
 
-    OrbitManipulatorMouseKeyboardController.prototype = {
+    OrbitManipulatorStandardMouseKeyboardController.prototype = {
         init: function () {
             this.releaseButton();
             this._rotateKey = 65; // a
@@ -153,5 +155,5 @@ define( [
         }
 
     };
-    return OrbitManipulatorMouseKeyboardController;
+    return OrbitManipulatorStandardMouseKeyboardController;
 } );

--- a/sources/osgGA/osgGA.js
+++ b/sources/osgGA/osgGA.js
@@ -1,20 +1,21 @@
 define( [
     'hammer',
     'osgGA/FirstPersonManipulator',
-    'osgGA/FirstPersonManipulatorMouseKeyboardController',
-    'osgGA/FirstPersonManipulatorOculusController',
     'osgGA/FirstPersonManipulatorDeviceOrientationController',
+    'osgGA/FirstPersonManipulatorHammerController',
+    'osgGA/FirstPersonManipulatorOculusController',
+    'osgGA/FirstPersonManipulatorStandardMouseKeyboardController',
     'osgGA/Manipulator',
     'osgGA/OrbitManipulator',
+    'osgGA/OrbitManipulatorDeviceOrientationController',
     'osgGA/OrbitManipulatorGamePadController',
     'osgGA/OrbitManipulatorHammerController',
     'osgGA/OrbitManipulatorLeapMotionController',
-    'osgGA/OrbitManipulatorMouseKeyboardController',
-    'osgGA/OrbitManipulatorDeviceOrientationController',
     'osgGA/OrbitManipulatorOculusController',
+    'osgGA/OrbitManipulatorStandardMouseKeyboardController',
     'osgGA/SwitchManipulator',
     'osgGA/OrbitManipulatorEnums'
-], function ( Hammer, FirstPersonManipulator, FirstPersonManipulatorMouseKeyboardController, FirstPersonManipulatorOculusController, FirstPersonManipulatorDeviceOrientationController, Manipulator, OrbitManipulator, OrbitManipulatorGamePadController, OrbitManipulatorHammerController, OrbitManipulatorLeapMotionController, OrbitManipulatorMouseKeyboardController, OrbitManipulatorDeviceOrientationController, OrbitManipulatorOculusController, SwitchManipulator, OrbitManipulatorEnums ) {
+], function ( Hammer, FirstPersonManipulator, FirstPersonManipulatorDeviceOrientationController, FirstPersonManipulatorHammerController, FirstPersonManipulatorStandardMouseKeyboardController, FirstPersonManipulatorOculusController, Manipulator, OrbitManipulator, OrbitManipulatorDeviceOrientationController, OrbitManipulatorGamePadController, OrbitManipulatorHammerController, OrbitManipulatorLeapMotionController, OrbitManipulatorStandardMouseKeyboardController, OrbitManipulatorOculusController, SwitchManipulator, OrbitManipulatorEnums ) {
 
     'use strict';
 
@@ -23,17 +24,23 @@ define( [
     Hammer.NO_MOUSEEVENTS = true; // disable hammer js mouse events
 
     osgGA.FirstPersonManipulator = FirstPersonManipulator;
+    osgGA.getFirstPersonDeviceOrientationController = function () {
+        return FirstPersonManipulatorDeviceOrientationController;
+    };
+    osgGA.getFirstPersonManipulatorHammerController = function () {
+        return FirstPersonManipulatorHammerController;
+    };
     osgGA.getFirstPersonStandardMouseKeyboardControllerClass = function () {
-        return FirstPersonManipulatorMouseKeyboardController;
+        return FirstPersonManipulatorStandardMouseKeyboardController;
     };
     osgGA.getFirstPersonOculusControllerClass = function () {
         return FirstPersonManipulatorOculusController;
     };
-    osgGA.getFirstPersonDeviceOrientationController = function () {
-        return FirstPersonManipulatorDeviceOrientationController;
-    };
     osgGA.Manipulator = Manipulator;
     osgGA.OrbitManipulator = OrbitManipulator;
+    osgGA.getOrbitManipulatorDeviceOrientationController = function () {
+        return OrbitManipulatorDeviceOrientationController;
+    };
     osgGA.getOrbitManipulatorGamePadController = function () {
         return OrbitManipulatorGamePadController;
     };
@@ -43,11 +50,8 @@ define( [
     osgGA.getOrbitManipulatorLeapMotionController = function () {
         return OrbitManipulatorLeapMotionController;
     };
-    osgGA.getOrbitManipulatorMouseKeyboardController = function () {
-        return OrbitManipulatorMouseKeyboardController;
-    };
-    osgGA.getOrbitManipulatorDeviceOrientationController = function () {
-        return OrbitManipulatorDeviceOrientationController;
+    osgGA.getOrbitManipulatorStandardMouseKeyboardController = function () {
+        return OrbitManipulatorStandardMouseKeyboardController;
     };
     osgGA.getOrbitManipulatorOculusController = function () {
         return OrbitManipulatorOculusController;


### PR DESCRIPTION
These stuffs have been bothering me since ages :).

commit 1 : if we rotate with one finger and then adds a second one, it now moves to pan mode.
It's something that has been bothering me A LOT on mobile since I often failed to correctly pan on first try.

commit 2 : fps manipulator is fully operational on mobile now.
Also, firstPersonManipulator's computeHomePosition now set the distance (speed) depending of the home bounding box (that way if we use the FPS manipulator in the exemples there's no need to set manually the distance to get correct pan speed).

commit 3 : It's faster when we zoom out. Maybe it's not the best way to do it but it helps a lot for now.

commit 4: Kind of experimental, if we zoom a lot and hit the minDistance pivot point, I added an option to move the pivot itself and continue "zooming".
I think it can help for people who screw up the orbit and can't zoom anymore.
It can also help if the pivot point is on the surface but we still want to go through it by zooming (otherwise there's no easy way to go inside, it's typically super bothersome when the pivot point is on a backfaced or transparent triangle and you are "stuck in the mud").

However, in order to work correctly, the minDistance shouldn't be too small.
For now the minDistance has to be set manually (typically something like  ``this.getHomeDistance( this.getHomeBound( bool ) ) * 0.1``).
I didn't want to call getHomeBound on each frame because I feared it could be costly (and I don't know when to cache/update it), so for now it's the application that should update the minDistance.