### PR TITLE
[#103412958] Fixes Bluebird embedding in the osgjs build

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -14,7 +14,7 @@
     </script>
 
     <script type='text/javascript' src='vendors/jquery-1.4.2.js'></script>
-    <script type='text/javascript' src='../examples/vendors/q.js'></script>
+    <script type='text/javascript' src='../examples/vendors/bluebird.js'></script>
     <script type='text/javascript' src='../examples/vendors/hammer.js'></script>
     <script type='text/javascript' src='../examples/vendors/leap.js'></script>
 </head>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,11 +35,11 @@ module.exports = {
             amd: 'zlib'
         }
     }, {
-        'q': {
-            root: 'Q',
-            commonjs2: 'q',
-            commonjs: 'q',
-            amd: 'q'
+        'bluebird': {
+            root: 'P',
+            commonjs2: 'bluebird',
+            commonjs: 'bluebird',
+            amd: 'bluebird'
         }
     }, {
         'hammer': {


### PR DESCRIPTION
Transition to Q library of promises to Bluebird left a missing external dependency check. Now bluebird won't be embedded anymore in the osg.js build