### PR TITLE
[#100330416] Makes gamepad controls disableable

### DIFF
--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -583,7 +583,8 @@ define( [
                 var initialize = true;
                 var argDevice = {};
                 if ( argumentEventBackend && ( argumentEventBackend[ device ] !== undefined ) ) {
-                    initialize = argumentEventBackend[ device ].enable || true;
+                    var bool = argumentEventBackend[ device ].enable;
+                    initialize = bool !== undefined ? bool : true;
                     argDevice = argumentEventBackend[ device ];
                 }
 

--- a/sources/osgViewer/eventProxy/GamePad.js
+++ b/sources/osgViewer/eventProxy/GamePad.js
@@ -69,6 +69,9 @@ define( [
         update: function () {
             // we poll instead
 
+            if ( !this.isValid() )
+                return;
+
             var gamepad = this.gamepadPoll();
             if ( !gamepad )
                 return;


### PR DESCRIPTION
The check performed on argumentEventBackend.device.enable could never be false so it could never be disabled. Additionally check isValid within the GamePad class itself so we can always alter the _enable prop to control the feature.