### PR TITLE
Makes WebGLCaps a singleton

### DIFF
--- a/examples/shadowmap/main.js
+++ b/examples/shadowmap/main.js
@@ -308,11 +308,11 @@
             var gui = new window.dat.GUI();
 
             var textureTypes = [ 'UNSIGNED_BYTE' ];
-            if ( this._hasAnyFloatTexSupport ) {
-                if ( this._halfFloatTexSupport ) textureTypes.push( 'HALF_FLOAT' );
-                if ( this._halfFloatLinearTexSupport ) textureTypes.push( 'HALF_FLOAT_LINEAR' );
-                if ( this._floatLinearTexSupport ) textureTypes.push( 'FLOAT_LINEAR' );
-                if ( this._floatTexSupport ) textureTypes.push( 'FLOAT' );
+            if ( this._hasAnyFloatTextureSupport ) {
+                if ( this._halfFloatTextureSupport ) textureTypes.push( 'HALF_FLOAT' );
+                if ( this._halfFloatLinearTextureSupport ) textureTypes.push( 'HALF_FLOAT_LINEAR' );
+                if ( this._floatLinearTextureSupport ) textureTypes.push( 'FLOAT_LINEAR' );
+                if ( this._floatTextureSupport ) textureTypes.push( 'FLOAT' );
             }
 
 
@@ -334,14 +334,14 @@
             controller = gui.add( this._config, 'textureType', textureTypes );
             controller.onChange( this.updateShadow.bind( this ) );
 
-            var texSizes = [];
-            var maxTexSize = this._maxTexSize;
-            var texSize = 16;
-            while ( texSize <= maxTexSize ) {
-                texSizes.push( texSize );
-                texSize *= 2;
+            var textureSizes = [];
+            var maxTextureSize = this._maxTextureSize;
+            var textureSize = 16;
+            while ( textureSize <= maxTextureSize ) {
+                textureSizes.push( textureSize );
+                textureSize *= 2;
             }
-            controller = gui.add( this._config, 'textureSize', texSizes );
+            controller = gui.add( this._config, 'textureSize', textureSizes );
             controller.onChange( this.updateShadow.bind( this ) );
 
             // shaders has to have under max varying decl
@@ -1284,14 +1284,14 @@
 
             this._glContext = viewer.getGraphicContext();
 
-            this._maxVaryings = this._viewer.getWebGLCaps().getWebGLParameter( 'MAX_VARYING_VECTORS' );
-            this._maxTexSize = this._viewer.getWebGLCaps().getWebGLParameter( 'MAX_TEXTURE_SIZE' );
+            this._maxVaryings = osg.WebGLCaps.instance().getWebGLParameter( 'MAX_VARYING_VECTORS' );
+            this._maxTextureSize = osg.WebGLCaps.instance().getWebGLParameter( 'MAX_TEXTURE_SIZE' );
 
-            this._floatLinearTexSupport = this._viewer.getWebGLCaps().hasRTTLinearFloat();
-            this._floatTexSupport = this._viewer.getWebGLCaps().hasRTTLinearFloat();
-            this._halfFloatLinearTexSupport = this._viewer.getWebGLCaps().hasRTTHalfFloat();
-            this._halfFloatTexSupport = this._viewer.getWebGLCaps().hasRTTLinearHalfFloat();
-            this._hasAnyFloatTexSupport = this._floatLinearTexSupport || this._floatTexSupport || this._halfFloatLinearTexSupport || this._halfFloatTexSupport;
+            this._floatLinearTextureSupport = osg.WebGLCaps.instance().hasLinearFloatRTT();
+            this._floatTextureSupport = osg.WebGLCaps.instance().hasFloatRTT();
+            this._halfFloatLinearTextureSupport = osg.WebGLCaps.instance().hasHalfFloatRTT();
+            this._halfFloatTextureSupport = osg.WebGLCaps.instance().hasLinearHalfFloatRTT();
+            this._hasAnyFloatTextureSupport = this._floatLinearTextureSupport || this._floatTextureSupport || this._halfFloatLinearTextureSupport || this._halfFloatTextureSupport;
 
             var scene = this.createScene();
 
@@ -1313,6 +1313,9 @@
     };
     // execute loaded code when ready
     window.addEventListener( 'load', function () {
+
+        osg.log( osg.WebGLCaps.instance().getWebGLParameters() );
+
         var example = new Example();
         var canvas = document.getElementById( 'View' );
         example.run( canvas );

--- a/sources/osg/WebGLCaps.js
+++ b/sources/osg/WebGLCaps.js
@@ -1,23 +1,94 @@
 define( [
-    'osg/Texture'
-], function ( Texture ) {
+    'osg/Texture',
+    'osgViewer/webgl-utils'
+], function ( Texture, WebGLUtils ) {
 
     'use strict';
 
-    var WebGLCaps = function ( gl ) {
-        this._gl = gl;
+    var WebGLCaps = function () {
+
         this._checkRTT = {};
         this._webGLExtensions = {};
         this._webGLParameters = {};
         this._webGLShaderMaxInt = 'NONE';
         this._webGLShaderMaxFloat = 'NONE';
+
+        this._bugsDB = {};
+        this._webGLPlatforms = {};
+    };
+
+    WebGLCaps.instance = function () {
+
+        if ( !WebGLCaps._instance ) {
+
+            var c = document.createElement( 'canvas' );
+            c.width = 32;
+            c.height = 32;
+
+            var gl = WebGLUtils.setupWebGL( c );
+
+            // gracefully handle non webgl
+            // like nodejs, phantomjs
+            if ( gl ) {
+
+                WebGLCaps._instance = new WebGLCaps();
+                WebGLCaps._instance.init( gl );
+
+            }
+
+            //delete c;
+
+        }
+        return WebGLCaps._instance;
     };
 
     WebGLCaps.prototype = {
-        init: function () {
-            this.initWebGLParameters();
-            this.initWebGLExtensions();
+        init: function ( gl ) {
+
+            // get capabilites
+            this.initWebGLParameters( gl );
+
+            // order is important
+            // to allow webgl extensions filtering
+            this.initPlatformSupport();
+            this.initBugDB();
+
+            // get extension
+            this.initWebGLExtensions( gl );
+
+            // get float support
+            this.hasLinearHalfFloatRTT( gl );
+            this.hasLinearFloatRTT( gl );
+            this.hasHalfFloatRTT( gl );
+            this.hasFloatRTT( gl );
+
         },
+        // inevitable bugs per platform (browser/OS/GPU)
+        initBugDB: function () {
+
+            var p = this._webGLPlatforms;
+            var ext = this._webGLParameters;
+
+            // derivatives gives strange results on Shadow Shaders
+            this._bugsDB[ 'OES_standard_derivatives' ] = ( p.Apple && ext.UNMASKED_VENDOR_WEBGL === undefined ) || ( ext.UNMASKED_VENDOR_WEBGL.indexOf( 'Intel' ) !== -1 && p.Apple );
+
+        },
+        initPlatformSupport: function () {
+
+            var p = this._webGLPlatforms;
+
+            p.Apple = navigator.vendor.indexOf( 'Apple' ) !== -1 || navigator.vendor.indexOf( 'OS X' ) !== -1;
+            // degrades complexity on handhelds.
+            p.Mobile = /Mobi/.test( navigator.userAgent ) || /ablet/.test( navigator.userAgent );
+
+        },
+        getWebGLPlatform: function ( str ) {
+            return this._webGLPlatforms[ str ];
+        },
+        getWebGLPlatforms: function () {
+            return this._webGLPlatforms;
+        },
+
         getWebGLParameter: function ( str ) {
             return this._webGLParameters[ str ];
         },
@@ -30,13 +101,16 @@ define( [
         getShaderMaxPrecisionInt: function () {
             return this._webGLParameters.MAX_SHADER_PRECISION_INT;
         },
-        checkRTTSupport: function ( typeFloat, typeTexture ) {
-            var gl = this._gl;
-            if ( gl === undefined )
-                return false;
+        checkSupportRTT: function ( gl, typeFloat, typeTexture ) {
+
+            if ( !gl ) return false;
+
             var key = typeFloat + ',' + typeTexture;
+
+            // check once only
             if ( this._checkRTT[ key ] !== undefined )
                 return this._checkRTT[ key ];
+
             // from http://codeflow.org/entries/2013/feb/22/how-to-write-portable-webgl/#how-can-i-detect-if-i-can-render-to-floating-point-textures
 
             // setup the texture
@@ -62,23 +136,20 @@ define( [
 
             return status;
         },
-        hasRTTLinearHalfFloat: function () {
-            return this._webGLExtensions[ 'OES_texture_half_float_linear' ] && this.checkRTTSupport( Texture.HALF_FLOAT, Texture.LINEAR );
+        hasLinearHalfFloatRTT: function ( gl ) {
+            return this._webGLExtensions[ 'OES_texture_half_float_linear' ] && this.checkSupportRTT( gl, Texture.HALF_FLOAT, Texture.LINEAR );
         },
-        hasRTTLinearFloat: function () {
-            return this._webGLExtensions[ 'OES_texture_float_linear' ] && this.checkRTTSupport( Texture.FLOAT, Texture.LINEAR );
+        hasLinearFloatRTT: function ( gl ) {
+            return this._webGLExtensions[ 'OES_texture_float_linear' ] && this.checkSupportRTT( gl, Texture.FLOAT, Texture.LINEAR );
         },
-        hasRTTHalfFloat: function () {
-            return this._webGLExtensions[ 'OES_texture_half_float' ] && this.checkRTTSupport( Texture.HALF_FLOAT, Texture.NEAREST );
+        hasHalfFloatRTT: function ( gl ) {
+            return this._webGLExtensions[ 'OES_texture_half_float' ] && this.checkSupportRTT( gl, Texture.HALF_FLOAT, Texture.NEAREST );
         },
-        hasRTTFloat: function () {
-            return this._webGLExtensions[ 'OES_texture_float' ] && this.checkRTTSupport( Texture.FLOAT, Texture.NEAREST );
+        hasFloatRTT: function ( gl ) {
+            return this._webGLExtensions[ 'OES_texture_float' ] && this.checkSupportRTT( gl, Texture.FLOAT, Texture.NEAREST );
         },
-        initWebGLParameters: function () {
-            var gl = this._gl;
-            if ( gl === undefined )
-                return;
-
+        initWebGLParameters: function ( gl ) {
+            if ( !gl ) return;
             var limits = [
                 'MAX_COMBINED_TEXTURE_IMAGE_UNITS',
                 'MAX_CUBE_MAP_TEXTURE_SIZE',
@@ -132,6 +203,14 @@ define( [
                 params.MAX_SHADER_PRECISION_INT = 'none';
             }
 
+            // get GPU, Angle or not, Opengl/directx, etc.
+            //  ffx && chrome only
+            var debugInfo = gl.getExtension( 'WEBGL_debug_renderer_info' );
+            if ( debugInfo ) {
+                params.UNMASKED_RENDERER_WEBGL = gl.getParameter( debugInfo.UNMASKED_VENDOR_WEBGL );
+                params.UNMASKED_VENDOR_WEBGL = gl.getParameter( debugInfo.UNMASKED_RENDERER_WEBGL );
+
+            }
             // TODO ?
             // try to compile a small shader to test the spec is respected
         },
@@ -141,15 +220,26 @@ define( [
         getWebGLExtensions: function () {
             return this._webGLExtensions;
         },
-        initWebGLExtensions: function () {
-            var gl = this._gl;
-            if ( gl === undefined )
-                return;
+        initWebGLExtensions: function ( gl, filterBugs ) {
+
+            // nodejs, phantomjs
+            if ( !gl ) return;
+
+            var doFilter = filterBugs;
+            if ( doFilter === undefined )
+                doFilter = true;
+
             var supported = gl.getSupportedExtensions();
             var ext = this._webGLExtensions;
             // we load all the extensions
             for ( var i = 0, len = supported.length; i < len; ++i ) {
                 var sup = supported[ i ];
+
+                if ( doFilter && this._bugsDB[ sup ] ) {
+                    // bugs on that configuration, do not enable
+                    continue;
+                }
+
                 ext[ sup ] = gl.getExtension( sup );
             }
 

--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -21,6 +21,7 @@ define( [
     'osg/Vec3',
     'osg/Vec4',
     'osg/Viewport',
+    'osg/WebGLCaps',
     'osgShader/ShaderProcessor',
     'osgShadow/ShadowReceiveAttribute',
     'osgShadow/ShadowCasterVisitor',
@@ -28,7 +29,7 @@ define( [
     'osgShadow/ShadowCastAttribute',
     'osgShadow/ShadowTechnique',
     'osgShadow/ShadowTexture'
-], function ( BoundingBox, BlendFunc, Camera, ComputeBoundsVisitor, Depth, FrameBufferObject, Light, LightSource, Matrix, Notify, NodeVisitor, Program, Shader, StateAttribute, StateSet, Texture, Transform, Uniform, MACROUTILS, Vec3, Vec4, Viewport, ShaderProcessor, ShadowReceiveAttribute, ShadowCasterVisitor, ShadowFrustumIntersection, ShadowCastAttribute, ShadowTechnique, ShadowTexture ) {
+], function ( BoundingBox, BlendFunc, Camera, ComputeBoundsVisitor, Depth, FrameBufferObject, Light, LightSource, Matrix, Notify, NodeVisitor, Program, Shader, StateAttribute, StateSet, Texture, Transform, Uniform, MACROUTILS, Vec3, Vec4, Viewport, WebGLCaps, ShaderProcessor, ShadowReceiveAttribute, ShadowCasterVisitor, ShadowFrustumIntersection, ShadowCastAttribute, ShadowTechnique, ShadowTexture ) {
 
     'use strict';
 
@@ -398,7 +399,7 @@ define( [
 
             // prevent unnecessary texture bindings on all texture unit
             // TODO: actually get the real max texture unit from webglCaps
-            var shouldGetMaxTextureUnits = 32;
+            var shouldGetMaxTextureUnits = WebGLCaps.instance().getWebGLParameter( 'MAX_TEXTURE_IMAGE_UNITS' );
             for ( var k = 0; k < shouldGetMaxTextureUnits; k++ ) {
                 // bind  null texture which OSGJS will not bind,
                 // effectively preventing any other texture bind

--- a/sources/osgShadow/ShadowReceiveAttribute.js
+++ b/sources/osgShadow/ShadowReceiveAttribute.js
@@ -166,9 +166,7 @@ define( [
         getExtensions: function () {
             var algo = this.getAlgorithm();
             if ( algo === 'PCF' ) {
-                return [];
-                // looks like derivative is broken on some mac + intel cg ...
-                // return [ '#extension GL_OES_standard_derivatives : enable' ];
+                return [ '#extension GL_OES_standard_derivatives : enable' ];
             } else {
                 return [];
             }

--- a/sources/osgShadow/shaders/shadowsReceiveMain.glsl
+++ b/sources/osgShadow/shaders/shadowsReceiveMain.glsl
@@ -69,13 +69,13 @@
 
 
 // looks like derivative is broken on some mac + intel cg ...
-// #ifdef GL_OES_standard_derivatives
+#ifdef GL_OES_standard_derivatives
 
-//     shadowBiasPCF.x +=  dFdx(shadowUV.xy).x * shadowMapSize.z;
-//     shadowBiasPCF.y +=  dFdy(shadowUV.xy).y * shadowMapSize.w;
+     shadowBiasPCF.x +=  dFdx(shadowUV.xy).x * shadowMapSize.z;
+     shadowBiasPCF.y +=  dFdy(shadowUV.xy).y * shadowMapSize.w;
 //     //shadowBias += dFdx(shadowReceiverZ);
 
-// #endif
+#endif
 
 
     shadow = getShadowPCF(tex, shadowMapSize, shadowUV, shadowReceiverZ, shadowBiasPCF);

--- a/sources/osgViewer/View.js
+++ b/sources/osgViewer/View.js
@@ -61,7 +61,6 @@ define( [
         this._frameStamp = new FrameStamp();
         this._lightingMode = undefined;
         this._manipulator = undefined;
-        this._webGLCaps = undefined;
         this._canvasWidth = 0;
         this._canvasHeight = 0;
 
@@ -104,13 +103,15 @@ define( [
             return this.getCamera().getRenderer().getState().getGraphicContext();
         },
 
-        getWebGLCaps: function () {
-            return this._webGLCaps;
-        },
 
         initWebGLCaps: function ( gl ) {
-            this._webGLCaps = new WebGLCaps( gl );
-            this._webGLCaps.init();
+
+            var glCaps = WebGLCaps.instance();
+
+            if ( glCaps ) {
+                glCaps.initWebGLExtensions( gl );
+            }
+
         },
 
         computeCanvasSize: ( function () {


### PR DESCRIPTION
Makes it now viewer independant, can be called even before osg viewer
initialisation, uses its own canvas.
Viewer still needs to enable extension for their canvas
Adds platform information to start degrading gracefull only on defect gpu/os/browser instead of degrading everyone.