### PR TITLE
[#DEV-6234] Adds Camera::resetAttachments

### DIFF
--- a/sources/osg/Camera.js
+++ b/sources/osg/Camera.js
@@ -154,8 +154,26 @@ Camera.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit(
         detachAll: function () {
             this._attachments = {};
 
-            if ( this.frameBufferObject )
+            if ( this.frameBufferObject ) {
                 this.frameBufferObject.dirty();
+            }
+        },
+
+        // TODO: fix in case of shared fbo
+        // TODO: fix adding a resize case
+        resetAttachments: function () {
+
+
+            if ( this.frameBufferObject ) {
+
+                this.frameBufferObject.reset();
+                // remove framebuffer
+                this.frameBufferObject = 0;
+            }
+
+            // removes camera attachement
+            this._attachments = {};
+
         },
 
         attachTexture: function ( bufferComponent, texture, textureTarget ) {

--- a/tests/mockup/mockup.js
+++ b/tests/mockup/mockup.js
@@ -119,13 +119,31 @@ var createFakeRenderer = function () {
         enableVertexAttribArray: function () {},
         vertexAttribPointer: function () {},
         createTexture: function () {},
+        createFramebuffer: function () {
+            return 1;
+        },
+        deleteFramebuffer: function () {},
         bindFramebuffer: function () {},
+        framebufferTexture2D: function () {},
+        checkFramebufferStatus: function () {
+            return 0x8CD5;
+        },
+        createRenderbuffer: function () {
+            return 1;
+        },
+        deleteRenderbuffer: function () {},
+        bindRenderbuffer: function () {},
+        renderbufferStorage: function () {},
+        framebufferRenderbuffer: function () {},
         clear: function () {},
         viewport: function () {},
         cullFace: function () {},
         texImage2D: function () {},
         texParameteri: function () {},
-        createShader: function () {},
+        createShader: function () {
+            return 1;
+        },
+        deleteShader: function () {},
         shaderSource: function () {},
         compileShader: function () {},
         getShaderParameter: function () {
@@ -133,7 +151,10 @@ var createFakeRenderer = function () {
         },
         isContextLost: function () {},
         getShaderInfoLog: function () {},
-        createProgram: function () {},
+        createProgram: function () {
+            return 1;
+        },
+        deleteProgram: function () {},
         attachShader: function () {},
         validateProgram: function () {},
         linkProgram: function () {},

--- a/tests/osg/FrameBufferObject.js
+++ b/tests/osg/FrameBufferObject.js
@@ -1,0 +1,49 @@
+'use strict';
+var QUnit = require( 'qunit' );
+var mockup = require( 'tests/mockup/mockup' );
+var FrameBufferObject = require( 'osg/FrameBufferObject' );
+
+
+module.exports = function () {
+    QUnit.module( 'osg' );
+
+    QUnit.test( 'FrameBufferObject', function () {
+
+        ( function () {
+            var gl = mockup.createFakeRenderer();
+            var state = {
+                getGraphicContext: function () {
+                    return gl;
+                },
+                applyTextureAttribute: function () {}
+            };
+
+
+            var b = new FrameBufferObject();
+            b.setAttachment( {
+                texture: {
+                    getTextureObject: function () {
+                        return {
+                            id: function () {}
+                        };
+                    }
+                },
+                textureTarget: 'textureTarget'
+            } );
+            b.setAttachment( {
+                format: 'texture',
+                width: 512,
+                height: 512
+            } );
+
+            b.dirty();
+            b.apply( state );
+
+            ok( b._fbo !== undefined, 'Check we created gl framebuffer' );
+            b.releaseGLObjects();
+            ok( b._fbo === undefined, 'Check we released gl famebuffer' );
+
+
+        } )();
+    } );
+};

--- a/tests/osg/osgTests.js
+++ b/tests/osg/osgTests.js
@@ -11,6 +11,7 @@ var ComputeMatrixFromNodePath = require( 'tests/osg/ComputeMatrixFromNodePath' )
 var CullFace = require( 'tests/osg/CullFace' );
 var CullVisitor = require( 'tests/osg/CullVisitor' );
 var Depth = require( 'tests/osg/Depth' );
+var FrameBufferObject = require( 'tests/osg/FrameBufferObject' );
 var KdTree = require( 'tests/osg/KdTree' );
 var Light = require( 'tests/osg/Light' );
 var Matrix = require( 'tests/osg/Matrix' );
@@ -45,6 +46,7 @@ module.exports = function () {
     CullVisitor();
     CullFace();
     Depth();
+    FrameBufferObject();
     KdTree();
     Light();
     Matrix();


### PR DESCRIPTION
Allows to correctly remove/delete fbo/rbo, if user want to resize a render target