### PR TITLE
Fixes null projectionMatrix GL Calls

### DIFF
--- a/sources/osg/State.js
+++ b/sources/osg/State.js
@@ -264,10 +264,13 @@ State.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( Objec
         var mu = this.projectionMatrix;
 
         var mul = program._uniformsCache[ mu.name ];
-        Matrix.copy( matrix, mu.get() );
-        mu.dirty();
-        mu.apply( this.getGraphicContext(), mul );
+        if ( mul ) {
 
+            Matrix.copy( matrix, mu.get() );
+            mu.dirty();
+            mu.apply( this.getGraphicContext(), mul );
+
+        }
     },
 
     applyStateSet: function ( stateset ) {


### PR DESCRIPTION
Latest compositor uses fakeFullscreenQuad which
doesn't need any matrix to render on screen, but
osgjs code alway tried to bind a projectionMatrix