### PR TITLE
Adds Webgl2 Support When available

### DIFF
--- a/sources/osg/Options.js
+++ b/sources/osg/Options.js
@@ -8,7 +8,8 @@ var OptionsDefault = {
     'enableFrustumCulling': false,
     'stats': false, // display canvas with stats for the viewer
     'statsNoGraph': false, // display only text
-    'scrollwheel': true
+    'scrollwheel': true,
+    'webgl2': false
 };
 
 var Options = function () {

--- a/sources/osg/WebGLCaps.js
+++ b/sources/osg/WebGLCaps.js
@@ -31,7 +31,6 @@ var WebGLCaps = function () {
     this._webGLParameters[ 'NUM_COMPRESSED_TEXTURE_FORMATS' ] = 0;
     this._webGLParameters[ 'MAX_SHADER_PRECISION_FLOAT' ] = 'none';
     this._webGLParameters[ 'MAX_SHADER_PRECISION_INT' ] = 'none';
-
 };
 
 WebGLCaps.instance = function () {
@@ -47,7 +46,6 @@ WebGLCaps.instance = function () {
         // with our webglcaps canvas
         var webglInspector = typeof window !== undefined && window.gli;
         var oldWebGLInspector;
-
         if ( webglInspector ) {
 
             oldWebGLInspector = window.gli.host.inspectContext;
@@ -98,12 +96,48 @@ WebGLCaps.prototype = {
         // get extension
         this.initWebGLExtensions( gl );
 
+        this._isGL2 = typeof window.WebGL2RenderingContext !== 'undefined' && gl instanceof window.WebGL2RenderingContext;
+
+        if ( this._isGL2 ) {
+
+            // osgjs code is webgl1, so we fake webgl2 capabilities
+            // and calls for retrocompatibility with webgl1
+            this._checkRTT[ Texture.FLOAT + ',' + Texture.NEAREST ] = true;
+            this._checkRTT[ Texture.HALF_FLOAT + ',' + Texture.NEAREST ] = true;
+            this._checkRTT[ Texture.FLOAT + ',' + Texture.LINEAR ] = true;
+            this._checkRTT[ Texture.HALF_FLOAT + ',' + Texture.LINEAR ] = true;
+
+            var nativeExtension = [
+                'OES_element_index_uint',
+                'EXT_sRGB',
+                'EXT_blend_minmax',
+                'EXT_frag_depth',
+                'WEBGL_depth_texture',
+                'EXT_shader_texture_lod',
+                'OES_standard_derivatives',
+                'OES_texture_float',
+                'OES_texture_half_float',
+                'OES_vertex_array_object',
+                'WEBGL_draw_buffers',
+                'OES_fbo_render_mipmap',
+                'ANGLE_instanced_arrays'
+            ];
+
+            var ext = WebGLCaps._instance.getWebGLExtensions();
+            for ( var i = 0, l = nativeExtension.length; i < l; i++ ) {
+                ext[ nativeExtension[ i ] ] = function () {};
+            }
+        }
+
         // get float support
         this.hasLinearHalfFloatRTT( gl );
         this.hasLinearFloatRTT( gl );
         this.hasHalfFloatRTT( gl );
         this.hasFloatRTT( gl );
 
+    },
+    isWebGL2: function () {
+        return this._isGL2;
     },
     // inevitable bugs per platform (browser/OS/GPU)
     initBugDB: function () {

--- a/sources/osgViewer/webgl-utils.js
+++ b/sources/osgViewer/webgl-utils.js
@@ -110,6 +110,7 @@ var WebGLUtils = function () {
         /** function:(msg) */
         opt_onError ) {
         function handleCreationError( msg ) {
+            if ( msg.indexOf( 'WebGL2' ) !== -1 ) return;
             var container = document.getElementsByTagName( "body" )[ 0 ];
             //var container = canvas.parentNode;
             if ( container ) {
@@ -149,7 +150,14 @@ var WebGLUtils = function () {
      * @return {!WebGLContext} The created context.
      */
     var create3DContext = function ( canvas, opt_attribs ) {
-        var names = [ "webgl", "experimental-webgl", "webkit-3d", "moz-webgl" ];
+
+        // only try to enable if URl options ?webgl2=1
+        var names = [];
+        if ( opt_attribs && opt_attribs.webgl2 ) {
+            names = names.concat( [ "webgl2", "experimental-webgl2" ] );
+        }
+        names = names.concat( [ "webgl", "experimental-webgl", "webkit-3d", "moz-webgl" ] );
+
         var context = null;
         for ( var ii = 0; ii < names.length; ++ii ) {
             try {


### PR DESCRIPTION
Chrome and Firefox have 100% support but both behind browser flags, so we can just use webgl2 context when available. 
It's progressive enhancement, as it mocks webgl1 extension and capabilities check so that it's all
transparent osgjs side.
Adds a  webglCaps.isWebGL2() in case of webgl2 only need to check feature when we'll progessively add them (texturearray, texture3d, ubo, etc.)