### PR TITLE
[#DEV-6449] Fix uncontrollable Body overwrite

### DIFF
--- a/sources/osg/WebGLCaps.js
+++ b/sources/osg/WebGLCaps.js
@@ -58,7 +58,7 @@ WebGLCaps.instance = function () {
             antialias: false
         };
 
-        var gl = WebGLUtils.setupWebGL( c, opt );
+        var gl = WebGLUtils.setupWebGL( c, opt, function () {} );
 
         WebGLCaps._instance = new WebGLCaps();
         if ( gl ) {


### PR DESCRIPTION
New webglCaps initializing the webgl context, but failing when browser
not supporting it, was doing it so without being controllable, thus
preventing user from controlling the "no webgl" error message.
No it reverts to previous user controllable scheme