### PR TITLE
Morph box faster box

### DIFF
--- a/benchmarks/index.html
+++ b/benchmarks/index.html
@@ -4,6 +4,13 @@
     <title>QUnit Benchmark Suite</title>
     <link rel='stylesheet' href='../tests/vendors/qunit/qunit.css' type='text/css' media='screen'>
 
+    <style>
+        /** Tests: un-collapse successful test */
+        .pass > ol {
+            display: block !important;
+        }
+    </style>
+
     <script type='text/javascript' src='../tests/vendors/es5-shim.js'></script>
     <script type='text/javascript' src='../tests/vendors/es6-shim.js'></script>
     <script type='text/javascript' src='../tests/vendors/qunit/qunit.js'></script>

--- a/benchmarks/osg/Geometry.js
+++ b/benchmarks/osg/Geometry.js
@@ -1,0 +1,35 @@
+'use strict';
+var QUnit = require( 'qunit' );
+var Shape = require( 'osg/Shape' );
+var Timer = require( 'osg/Timer' );
+var reportStats = require( 'benchmarks/reportStats' );
+
+module.exports = function () {
+
+    QUnit.module( 'osg Main Loop' );
+
+    test( 'ComputeBound', function () {
+
+        // 250 * 250 * 6 = 375k vertices (draw arrays...)
+        var geom = Shape.createTexturedSphere( 1.0, 250, 250 );
+        var timed = Timer.instance().tick();
+
+        console.profile();
+        console.time( 'time' );
+
+        var nCount = 5;
+        for ( var n = 0; n < nCount; n++ ) {
+            geom.dirtyBound();
+            geom.getBound();
+        }
+
+        console.timeEnd( 'time' );
+        console.profileEnd();
+
+        timed = Timer.instance().tick() - timed;
+
+        reportStats( timed, 'ComputeBound' );
+
+    } );
+
+};

--- a/benchmarks/osg/mainPerformance.js
+++ b/benchmarks/osg/mainPerformance.js
@@ -234,11 +234,11 @@ module.exports = function () {
         console.time( 'time' );
 
         var nCount = 20;
-        var s = Timer.now();
+        var s = Timer.instance().tick();
         for ( var n = 0; n < nCount; n++ ) {
             viewer.frame();
         }
-        var result = Timer.now() - s;
+        var result = Timer.instance().tick() - s;
 
         console.timeEnd( 'time' );
         console.profileEnd();

--- a/benchmarks/osg/osgBenchmarks.js
+++ b/benchmarks/osg/osgBenchmarks.js
@@ -1,12 +1,15 @@
 'use strict';
 var MainPerformance = require( 'benchmarks/osg/mainPerformance' );
+var Geometry = require( 'benchmarks/osg/Geometry' );
 var Visitor = require( 'benchmarks/osg/Visitor' );
 var Animations = require( 'benchmarks/osgAnimation/mainPerformance' );
+
 
 module.exports = function () {
 
     MainPerformance();
     Animations();
     Visitor();
+    Geometry();
 
 };

--- a/benchmarks/reportStats.js
+++ b/benchmarks/reportStats.js
@@ -1,30 +1,12 @@
 'use strict';
 
-module.exports = ( function () {
+module.exports = function ( timed, perfTarget, msg ) {
 
-    var reportStats = function () {
+    var logMsg = msg;
+    if ( logMsg === undefined ) {
+        logMsg = 'perf' + ( perfTarget ? ' of ' + perfTarget : '' ) + ' is: ' + ( timed ).toFixed() + ' ms';
+    }
 
-        if ( !navigator )
-            return true;
+    ok( true, logMsg );
 
-        if ( navigator.userAgent.indexOf( 'PhantomJS' ) !== -1 )
-            return true;
-
-        return false;
-
-    };
-
-    var benchmarkOk = function ( timed, perfTarget, msg ) {
-
-        var isCli = reportStats();
-        var logMsg = msg;
-        if ( logMsg === undefined ) {
-            logMsg = 'perf' + ( perfTarget ? ' of ' + perfTarget : '' ) + ' is: ' + ( timed ).toFixed() + ' ms';
-        }
-
-        ok( isCli, logMsg );
-
-    };
-
-    return benchmarkOk;
-} )();
+};

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -192,7 +192,7 @@
             myReservedMatrixStack.reset();
             osg.Matrix.transformVec3( osg.computeLocalToWorld( hits[ 0 ].nodepath.slice( 1 ), true, myReservedMatrixStack.get() ), point, worldPoint );
 
-            si.set( worldPoint, 5.0 );
+            si.set( worldPoint, viewer.getSceneData().getBound().radius() * 0.1 );
             var iv = new osgUtil.IntersectionVisitor();
             iv.setIntersector( si );
             viewer.getSceneData().accept( iv );

--- a/examples/picking/main.js
+++ b/examples/picking/main.js
@@ -69,7 +69,7 @@
 
     var loadModel = function ( data, viewer, node, unifs ) {
         var promise = osgDB.parseSceneGraph( data );
-        // var promise = osg.createTexturedSphere( 1.0, 500, 500 );
+        // var promise = P.resolve( osg.createTexturedSphere( 1.0, 500, 500 ) );
 
         promise.then( function ( child ) {
             node.addChild( child );

--- a/sources/osg/Geometry.js
+++ b/sources/osg/Geometry.js
@@ -2,7 +2,6 @@
 var MACROUTILS = require( 'osg/Utils' );
 var BoundingBox = require( 'osg/BoundingBox' );
 var Node = require( 'osg/Node' );
-var Vec3 = require( 'osg/Vec3' );
 
 
 /**
@@ -145,18 +144,42 @@ Geometry.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( No
     computeBoundingBox: function ( boundingBox ) {
 
         var vertexArray = this.getVertexAttributeList().Vertex;
-        var v = Vec3.create();
-        if ( vertexArray !== undefined &&
-            vertexArray.getElements() !== undefined &&
-            vertexArray.getItemSize() > 2 ) {
+        if ( vertexArray && vertexArray.getElements() && vertexArray.getItemSize() > 2 ) {
             var vertexes = vertexArray.getElements();
-            Vec3.init( v );
-            for ( var idx = 0, l = vertexes.length; idx < l; idx += 3 ) {
-                v[ 0 ] = vertexes[ idx ];
-                v[ 1 ] = vertexes[ idx + 1 ];
-                v[ 2 ] = vertexes[ idx + 2 ];
-                boundingBox.expandByVec3( v );
+            var itemSize = vertexArray.getItemSize();
+
+            var min = boundingBox.getMin();
+            var max = boundingBox.getMax();
+
+            var minx = min[ 0 ];
+            var miny = min[ 1 ];
+            var minz = min[ 2 ];
+            var maxx = max[ 0 ];
+            var maxy = max[ 1 ];
+            var maxz = max[ 2 ];
+
+            // if the box is un-initialized min=Inf and max=-Inf
+            // we can't simply write if(x > min) [...] else (x < max) [...]
+            // most of the time the else condition is run so it's a kinda useless
+            // optimization anyway
+            for ( var idx = 0, l = vertexes.length; idx < l; idx += itemSize ) {
+                var v1 = vertexes[ idx ];
+                var v2 = vertexes[ idx + 1 ];
+                var v3 = vertexes[ idx + 2 ];
+                if ( v1 < minx ) minx = v1;
+                if ( v1 > maxx ) maxx = v1;
+                if ( v2 < miny ) miny = v2;
+                if ( v2 > maxy ) maxy = v2;
+                if ( v3 < minz ) minz = v3;
+                if ( v3 > maxz ) maxz = v3;
             }
+
+            min[ 0 ] = minx;
+            min[ 1 ] = miny;
+            min[ 2 ] = minz;
+            max[ 0 ] = maxx;
+            max[ 1 ] = maxy;
+            max[ 2 ] = maxz;
         }
         return boundingBox;
     },

--- a/sources/osgAnimation/MorphGeometry.js
+++ b/sources/osgAnimation/MorphGeometry.js
@@ -66,13 +66,24 @@ MorphGeometry.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInheri
         return this._targetWeights;
     },
 
-    mergeChildrenVertexAttributeList: function () {
+    computeBoundingBox: function ( boundingBox ) {
+        Geometry.prototype.computeBoundingBox.call( this, boundingBox );
 
-        var target;
+        // expand bb with targets
+        // Note : if the morphs have many many targets it can be done more smartly in
+        // the UpdateMorph on each frame by just taking into account the "active morphs"
+        for ( var i = 0, l = this._targets.length; i < l; i++ ) {
+            this._targets[ i ].computeBoundingBox( boundingBox );
+        }
+
+        return boundingBox;
+    },
+
+    mergeChildrenVertexAttributeList: function () {
 
         for ( var i = 0, l = this._targets.length; i < l; i++ ) {
 
-            target = this._targets[ i ];
+            var target = this._targets[ i ];
 
             // change BufferArray to BufferArrayProxy
             var attributeList = target.getVertexAttributeList();

--- a/sources/osgUtil/LineSegmentIntersector.js
+++ b/sources/osgUtil/LineSegmentIntersector.js
@@ -15,13 +15,17 @@ var LineSegmentIntersector = function () {
 LineSegmentIntersector.prototype = {
     set: function ( start, end ) {
         Vec3.copy( start, this._start );
+        Vec3.copy( start, this._iStart );
         Vec3.copy( end, this._end );
+        Vec3.copy( end, this._iEnd );
     },
     setStart: function ( start ) {
         Vec3.copy( start, this._start );
+        Vec3.copy( start, this._iStart );
     },
     setEnd: function ( end ) {
         Vec3.copy( end, this._end );
+        Vec3.copy( end, this._iEnd );
     },
     reset: function () {
         // Clear the intersections vector

--- a/sources/osgUtil/PolytopeIntersector.js
+++ b/sources/osgUtil/PolytopeIntersector.js
@@ -37,6 +37,8 @@ PolytopeIntersector.prototype = {
         this._referencePlane[ 1 ] = polytope[ polytope.length - 1 ][ 1 ];
         this._referencePlane[ 2 ] = polytope[ polytope.length - 1 ][ 2 ];
         this._referencePlane[ 3 ] = polytope[ polytope.length - 1 ][ 3 ];
+        // TODO initialize _iPolytope or _iReferencePlane in case there is no transform in the graph?
+        // same as setCurrentTransformation with matrix identity
     },
 
     setPolytopeFromWindowCoordinates: function ( xMin, yMin, xMax, yMax ) {

--- a/sources/osgUtil/TriangleSphereIntersector.js
+++ b/sources/osgUtil/TriangleSphereIntersector.js
@@ -57,6 +57,9 @@ TriangleSphereIntersector.prototype = MACROUTILS.objectInherit( TriangleIntersec
             var b1 = Vec3.dot( diff, edge2 );
             var c = Vec3.length2( diff );
             var det = Math.abs( a00 * a11 - a01 * a01 );
+            if ( det < 1e-10 )
+                return;
+
             var s = a01 * b1 - a11 * b0;
             var t = a01 * b0 - a00 * b1;
             var sqrDistance;


### PR DESCRIPTION
On the picking example with the highly tesselated sphere, the computation of box : 
- ~470 ms
- now, ~95ms

To give an overview of why "writing in array is slower" An alternate version (simpler but slower, ~145ms))
````
for ( var idx = 0, l = vertexes.length; idx < l; idx += itemSize ) {
    var v0 = vertexes[ idx ];
    var v1 = vertexes[ idx + 1 ];
    var v2 = vertexes[ idx + 2 ];
    if ( v1 > min[ 0 ] ) min[ 0 ] = v1;
    if ( v1 < max[ 0 ] ) max[ 0 ] = v1;
    if ( v2 > min[ 1 ] ) min[ 1 ] = v2;
    if ( v2 < max[ 1 ] ) max[ 1 ] = v2;
    if ( v3 > min[ 2 ] ) min[ 2 ] = v3;
    if ( v3 < max[ 2 ] ) max[ 2 ] = v3;
}
```

The 3 times are very consistent