### PR TITLE
[#DEV-6816] Adds special frame render

### DIFF
--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -223,7 +223,6 @@ Viewer.prototype = MACROUTILS.objectInherit( View.prototype, {
         if ( this.getScene().getSceneData() )
             this.getScene().getSceneData().getBound();
 
-
         if ( this.getCamera() ) {
 
             var stats = this._stats;
@@ -330,6 +329,29 @@ Viewer.prototype = MACROUTILS.objectInherit( View.prototype, {
 
     checkNeedToDoFrame: function () {
         return this._requestContinousUpdate || this._requestRedraw;
+    },
+
+    /// particular case
+    superSample: function ( frameCallback ) {
+
+        // make sure we're on the same spot.
+
+        if ( this.getCamera() ) {
+
+            var renderer = this.getCamera().getRenderer();
+
+            var i = 0;
+
+            while ( frameCallback( i++ ) ) {
+
+                this.getScene().updateSceneGraph( this._updateVisitor );
+                renderer.cull();
+                renderer.draw();
+
+            }
+
+        }
+
     },
 
     frame: function () {


### PR DESCRIPTION
rendering same frame N times wasn't possible as timestamp was
automatically updated, canvas size checked and manipulator might have intervened too.
Idea is to be able to optimize that use case further. Faster
cull/update/draw as nothing but some shader uniform change between frames