### PR TITLE
Bug/multiple output nodes dev 7081

### DIFF
--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -774,11 +774,11 @@ Compiler.prototype = {
         // allow overwrite by inheriting compiler
         // where shadow inputs ( NDotL notably)
         // can be used for non standard shadows
-        return this.connectShadowLightNode( lightedOutput, shadowedOutput, shadowInputs );
+        return this.connectShadowLightNode( light, lightedOutput, shadowedOutput, shadowInputs );
 
     },
 
-    connectShadowLightNode: function ( lightedOutput, shadowedOutput ) {
+    connectShadowLightNode: function ( light, lightedOutput, shadowedOutput ) {
 
         var lightAndShadowTempOutput = this.createVariable( 'vec3', 'lightAndShadowTempOutput' );
 

--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -10,6 +10,7 @@ var Compiler = function ( attributes, textureAttributes, shaderProcessor ) {
 
     this._activeNodeList = {};
     this._compiledNodeList = {};
+    this._traversedNodeList = {};
 
     this._variables = {};
     this._varyings = {};
@@ -204,6 +205,16 @@ Compiler.prototype = {
         } else {
             Notify.warn( 'Node not requested by using Compiler getNode and/or not registered in nodeFactory ' + n.toString() );
         }
+    },
+
+    // make sure we traverse once per evaluation of graph
+    checkOrMarkNodeAsTraversed: function ( n ) {
+        var cacheID = n.getID();
+        if ( this._traversedNodeList[ cacheID ] ) {
+            return true;
+        }
+        this._traversedNodeList[ cacheID ] = n;
+        return false;
     },
 
     getVariable: function ( nameID ) {
@@ -877,7 +888,11 @@ Compiler.prototype = {
                 inputs.eyeVector = this.getOrCreateNormalizedPosition();
 
             this.getNode( nodeName ).inputs( inputs ).outputs( {
-                color: lightedOutput
+                color: lightedOutput,
+                lightEyePos: inputs.lightEyePos, // spot and point only
+                lightEyeDir: inputs.lightEyeDir,
+                ndl: inputs.lightNDL,
+                lighted: inputs.lighted
             } );
 
             var shadowedOutput = this.createShadowingLight( light, inputs, lightedOutput );
@@ -926,6 +941,8 @@ Compiler.prototype = {
     // TODO: add a visitor to debug the graph
     traverse: function ( functor, node ) {
 
+        if ( this.checkOrMarkNodeAsTraversed( node ) ) return;
+
         var inputs = node.getInputs();
         if ( !Array.isArray( inputs ) ) {
             var keys = window.Object.keys( inputs );
@@ -947,10 +964,23 @@ Compiler.prototype = {
         }
         functor.call( functor, node );
 
-        // keep trace we visited.
+        // keep trace we visited
         this.markNodeAsVisited( node );
+
     },
 
+    // clean necessary bits before traversing
+    // called in each evaluate func belows
+    preTraverse: function ( visitor ) {
+
+        // store traversed list to prevent double traverse
+        this._traversedNodeList = {};
+
+        visitor._map = {};
+        visitor._text = [];
+
+        return visitor;
+    },
     // Gather a particular output field
     // for now one of
     // ['define', 'extensions']
@@ -983,8 +1013,7 @@ Compiler.prototype = {
 
         };
 
-        func._map = {};
-        func._text = [];
+        this.preTraverse( func );
 
         for ( var j = 0, jl = nodes.length; j < jl; j++ ) {
             this.traverse( func, nodes[ j ] );
@@ -1022,8 +1051,7 @@ Compiler.prototype = {
 
         };
 
-        func._map = {};
-        func._text = [];
+        this.preTraverse( func );
 
         for ( var j = 0, jl = nodes.length; j < jl; j++ ) {
             this.traverse( func, nodes[ j ] );
@@ -1056,8 +1084,9 @@ Compiler.prototype = {
             }
         };
 
-        func._map = {};
-        func._text = [];
+
+        this.preTraverse( func );
+
         for ( var j = 0, jl = nodes.length; j < jl; j++ ) {
             this.traverse( func, nodes[ j ] );
         }
@@ -1098,10 +1127,11 @@ Compiler.prototype = {
 
     evaluate: function ( nodes ) {
 
+
         var func = function ( node ) {
 
             var id = node.getID();
-            if ( this._mapTraverse[ id ] !== undefined ) {
+            if ( this._map[ id ] !== undefined ) {
                 return;
             }
 
@@ -1119,11 +1149,11 @@ Compiler.prototype = {
 
                 this._text.push( c );
             }
-            this._mapTraverse[ id ] = true;
+
+            this._map[ id ] = true;
         };
 
-        func._text = [];
-        func._mapTraverse = [];
+        this.preTraverse( func );
 
         for ( var j = 0, jl = nodes.length; j < jl; j++ ) {
             this.traverse( func, nodes[ j ] );


### PR DESCRIPTION
- Light Shader nodes outputs: color but also ndl, lighted.
When a shader node has mutliple output, and some are used by other node, they should be part of shader node graph traversal, otherwise dependency traversal is wrong.
fix osgjs traversal to handle that.
fix node with mutiple output so that they declare them explicitely.

- Adds Light to connecShadowLightMode