### PR TITLE
Removes extra pushStateSet when using insertStateSet

### DIFF
--- a/sources/osg/RenderLeaf.js
+++ b/sources/osg/RenderLeaf.js
@@ -1,4 +1,5 @@
 'use strict';
+var StateGraph = require( 'osg/StateGraph' );
 
 var CacheUniformApply = function ( state, program ) {
     this.modelWorldUniform = program._uniformsCache[ state.modelWorldMatrix.getName() ];
@@ -111,46 +112,92 @@ RenderLeaf.prototype = {
 
             var prevRenderGraph;
             var prevRenderGraphParent;
-            var rg;
+            var curRenderGraph = this._parent;
+            var curRenderGraphParent = curRenderGraph.parent;
+            var curRenderGraphStateSet = curRenderGraph.stateset;
+
+            // When rendering a RenderLeaf we try to limit the state change
+            // to do that Graph of State is created during the culling pass.
+            // this graph contains nodes of StateGraph type see the class StateGraph
+            //
+            // So to limit switching of StateSet we check where are the common parent
+            // between previous RenderLeaf and this current.
+            //
+            // There are 3 cases when there is a prev / current render leaf
+            //
+            //
+            // pRG: previousRenderGraph
+            // cRG: currentRenderGraph
+            // pRL: previousRenderLeaf
+            // cRL: currentRenderLeaf
+            // each RG contains a StateSet
+            //
+            //          A                        B                       C
+            // +-----+     +-----+            +-----+                 +-----+
+            // | pRG |     | cRG |         +--+ RG  +--+              | RG  |
+            // +--+--+     +--+--+         |  +-----+  |              +--+--+
+            //    |           |            |           |                 |
+            // +--v--+     +--v--+      +--v--+     +--v--+           +--v--+
+            // | pRG |     | cRG |      | pRG |     | cRG |        +--+ RG  +--+
+            // +--+--+     +--+--+      +--+--+     +--+--+        |  +-----+  |
+            //    |           |            |           |           |           |
+            // +--v--+     +--v--+      +--v--+     +--v--+     +--v--+     +--v--+
+            // | pRL |     | cRL |      | pRL |     | cRL |     | pRL |     | cRL |
+            // +-----+     +-----+      +-----+     +-----+     +-----+     +-----+
+            //
+            //
+            // Case A
+            // no common parent StateGraphNode we need to
+            // popStateSet until we find the common parent and then
+            // pushStateSet from the common parent to the current
+            // RenderLeaf
+            //
+            // Case B
+            // common parent StateGraphNode so we apply the current stateSet
+            //
+            // Case C
+            // the StateGraphNode is common to the previous RenderLeaf so we dont need
+            // to do anything except if we used an insertStateSet
+            //
 
             if ( previousLeaf !== undefined ) {
 
                 // apply state if required.
                 prevRenderGraph = previousLeaf._parent;
                 prevRenderGraphParent = prevRenderGraph.parent;
-                rg = this._parent;
 
-                if ( prevRenderGraphParent !== rg.parent ) {
+                if ( prevRenderGraphParent !== curRenderGraphParent ) {
 
-                    rg.moveStateGraph( state, prevRenderGraphParent, rg.parent );
+                    // Case A
+                    StateGraph.moveStateGraph( state, prevRenderGraphParent, curRenderGraphParent );
 
-                    // send state changes and matrix changes to OpenGL.
-
-                    state.applyStateSet( rg.stateset );
+                    state.applyStateSet( curRenderGraphStateSet );
                     previousHash = state.getStateSetStackHash();
 
-                } else if ( rg !== prevRenderGraph ) {
+                } else if ( curRenderGraph !== prevRenderGraph ) {
 
-                    // send state changes and matrix changes to OpenGL.
-                    state.applyStateSet( rg.stateset );
+                    // Case B
+                    state.applyStateSet( curRenderGraphStateSet );
                     previousHash = state.getStateSetStackHash();
 
                 } else {
+
+                    // Case C
 
                     // in osg we call apply but actually we dont need
                     // except if the stateSetStack changed.
                     // for example if insert/remove StateSet has been used
                     var hash = state.getStateSetStackHash();
                     if ( previousHash !== hash ) {
-                        state.applyStateSet( this._parent.stateset );
+                        state.applyStateSet( curRenderGraphStateSet );
                         previousHash = hash;
                     }
                 }
 
             } else {
 
-                this._parent.moveStateGraph( state, undefined, this._parent.parent );
-                state.applyStateSet( this._parent.stateset );
+                StateGraph.moveStateGraph( state, undefined, curRenderGraphParent );
+                state.applyStateSet( curRenderGraphStateSet );
                 previousHash = state.getStateSetStackHash();
 
             }

--- a/sources/osg/RenderLeaf.js
+++ b/sources/osg/RenderLeaf.js
@@ -142,7 +142,6 @@ RenderLeaf.prototype = {
                     // for example if insert/remove StateSet has been used
                     var hash = state.getStateSetStackHash();
                     if ( previousHash !== hash ) {
-                        this._parent.moveStateGraph( state, undefined, this._parent.parent );
                         state.applyStateSet( this._parent.stateset );
                         previousHash = hash;
                     }

--- a/sources/osg/StateGraph.js
+++ b/sources/osg/StateGraph.js
@@ -12,29 +12,42 @@ var StateGraph = function () {
 };
 
 StateGraph.prototype = {
+
     clean: function () {
-        this.leafs.splice( 0, this.leafs.length );
+
+        this.leafs.length = 0;
         this.stateset = undefined;
         this.parent = undefined;
         this.depth = 0;
-        var key, keys = this.children.keys;
+        var children = this.children;
+        var child;
+        var key, keys = children.keys;
+
         for ( var i = 0, l = keys.length; i < l; i++ ) {
+
             key = keys[ i ];
-            this.children[ key ].clean();
-            osgPool.memoryPools.stateGraph.put( this.children[ key ] );
+            child = children[ key ];
+            child.clean();
+            osgPool.memoryPools.stateGraph.put( child );
+
         }
+
         this.children = {};
-        keys.splice( 0, keys.length );
+        keys.length = 0;
         this.children.keys = keys;
     },
+
     getStateSet: function () {
         return this.stateset;
     },
 
     findOrInsert: function ( stateset ) {
+
         var sg;
         var stateSetID = stateset.getInstanceID();
-        if ( !this.children[ stateSetID ] ) {
+        var children = this.children;
+
+        if ( !children[ stateSetID ] ) {
 
             //sg = new StateGraph();
             sg = osgPool.memoryPools.stateGraph.get();
@@ -42,97 +55,95 @@ StateGraph.prototype = {
             sg.parent = this;
             sg.depth = this.depth + 1;
             sg.stateset = stateset;
-            this.children[ stateSetID ] = sg;
-            this.children.keys.push( stateSetID );
+            children[ stateSetID ] = sg;
+            children.keys.push( stateSetID );
+
         } else {
-            sg = this.children[ stateSetID ];
+
+            sg = children[ stateSetID ];
+
         }
         return sg;
-    },
-    moveToRootStateGraph: function ( state, sgCurrent ) {
-        // need to pop back all statesets and matrices.
-        while ( sgCurrent ) {
-            if ( sgCurrent.stateset ) {
-                state.popStateSet();
-            }
-            sgCurrent = sgCurrent.parent;
-        }
-    },
-    moveStateGraph: function ( state, sgCurrent, sgNew ) {
-        var stack = [];
-        var i, l;
-        if ( sgNew === sgCurrent || sgNew === undefined ) {
-            return;
-        }
+    }
 
-        if ( sgCurrent === undefined ) {
-            // push stateset from sgNew to root, and apply
-            // stateset from root to sgNew
-            do {
-                if ( sgNew.stateset !== undefined ) {
-                    stack.push( sgNew.stateset );
-                }
-                sgNew = sgNew.parent;
-            } while ( sgNew );
+};
 
-            for ( i = stack.length - 1, l = 0; i >= l; --i ) {
-                state.pushStateSet( stack[ i ] );
-            }
-            return;
-        } else if ( sgCurrent.parent === sgNew.parent ) {
-            // first handle the typical case which is two state groups
-            // are neighbours.
+StateGraph.moveStateGraph = function ( state, sgCurrentArg, sgNewArg ) {
 
-            // state has changed so need to pop old state.
-            if ( sgCurrent.stateset !== undefined ) {
-                state.popStateSet();
-            }
-            // and push new state.
-            if ( sgNew.stateset !== undefined ) {
-                state.pushStateSet( sgNew.stateset );
-            }
-            return;
-        }
+    var stack = [];
+    var sgNew = sgNewArg;
+    var sgCurrent = sgCurrentArg;
+    var i, l;
+    if ( sgNew === sgCurrent || sgNew === undefined ) return;
 
-        // need to pop back up to the same depth as the new state group.
-        while ( sgCurrent.depth > sgNew.depth ) {
-            if ( sgCurrent.stateset !== undefined ) {
-                state.popStateSet();
-            }
-            sgCurrent = sgCurrent.parent;
-        }
-
-        // use return path to trace back steps to sgNew.
-        stack = [];
-
-        // need to pop back up to the same depth as the curr state group.
-        while ( sgNew.depth > sgCurrent.depth ) {
+    if ( sgCurrent === undefined ) {
+        // push stateset from sgNew to root, and apply
+        // stateset from root to sgNew
+        do {
             if ( sgNew.stateset !== undefined ) {
                 stack.push( sgNew.stateset );
             }
             sgNew = sgNew.parent;
-        }
-
-        // now pop back up both parent paths until they agree.
-
-        // DRT - 10/22/02
-        // should be this to conform with above case where two StateGraph
-        // nodes have the same parent
-        while ( sgCurrent !== sgNew ) {
-            if ( sgCurrent.stateset !== undefined ) {
-                state.popStateSet();
-            }
-            sgCurrent = sgCurrent.parent;
-
-            if ( sgNew.stateset !== undefined ) {
-                stack.push( sgNew.stateset );
-            }
-            sgNew = sgNew.parent;
-        }
+        } while ( sgNew );
 
         for ( i = stack.length - 1, l = 0; i >= l; --i ) {
             state.pushStateSet( stack[ i ] );
         }
+        return;
+
+    } else if ( sgCurrent.parent === sgNew.parent ) {
+        // first handle the typical case which is two state groups
+        // are neighbours.
+
+        // state has changed so need to pop old state.
+        if ( sgCurrent.stateset !== undefined ) {
+            state.popStateSet();
+        }
+        // and push new state.
+        if ( sgNew.stateset !== undefined ) {
+            state.pushStateSet( sgNew.stateset );
+        }
+        return;
+    }
+
+    // need to pop back up to the same depth as the new state group.
+    while ( sgCurrent.depth > sgNew.depth ) {
+        if ( sgCurrent.stateset !== undefined ) {
+            state.popStateSet();
+        }
+        sgCurrent = sgCurrent.parent;
+    }
+
+    // use return path to trace back steps to sgNew.
+    stack = [];
+
+    // need to pop back up to the same depth as the curr state group.
+    while ( sgNew.depth > sgCurrent.depth ) {
+        if ( sgNew.stateset !== undefined ) {
+            stack.push( sgNew.stateset );
+        }
+        sgNew = sgNew.parent;
+    }
+
+    // now pop back up both parent paths until they agree.
+
+    // DRT - 10/22/02
+    // should be this to conform with above case where two StateGraph
+    // nodes have the same parent
+    while ( sgCurrent !== sgNew ) {
+        if ( sgCurrent.stateset !== undefined ) {
+            state.popStateSet();
+        }
+        sgCurrent = sgCurrent.parent;
+
+        if ( sgNew.stateset !== undefined ) {
+            stack.push( sgNew.stateset );
+        }
+        sgNew = sgNew.parent;
+    }
+
+    for ( i = stack.length - 1, l = 0; i >= l; --i ) {
+        state.pushStateSet( stack[ i ] );
     }
 };
 


### PR DESCRIPTION
When using insertStateSet and RenderLeaf use this codepath

```
var hash = state.getStateSetStackHash();
if ( previousHash !== hash ) {
    this._parent.moveStateGraph( state, undefined, this._parent.parent );
    state.applyStateSet( this._parent.stateset );
    previousHash = hash;
}
```

We where pushing all StateSet from the stateGraph ( from current to root
) on State.
So for example we had something like that in state after rendering
multiple RenderLeaf
[ 25, 39, 46, 567, 248, 251, 569, 565, 55, 257, 39, 46, 567, 248, 251,
569, 565, 55, 257, ... ]
the sequence [ 39, 46, 567, 248, 251, 569, 565, 55, 257 ] was repeated
because of moveStateGraph( state, undefined, this._parent.parent );
Actually this code path needs to re apply State's StateSet if an
insertStateSet has been used but does not need to push/pop any StateSet.
To re apply StateSet we still need to apply the one from the current
StateGraph because it is not pushed on the State's stack. So the fix is
just to remove the line:
```
moveStateGraph( state, undefined,this._parent.parent );
```