### PR TITLE
[DEV-7142] Remove Temp var shader node reuse

### DIFF
--- a/tests/osg/Image.js
+++ b/tests/osg/Image.js
@@ -7,7 +7,7 @@ module.exports = function () {
 
     QUnit.module( 'osg' );
 
-    QUnit.asyncTest( 'Image.isGreyScale grey image', function () {
+    QUnit.asyncTest( 'Image.isGreyScale grey image', 1, function () {
 
 
         var test = function ( img ) {
@@ -25,7 +25,7 @@ module.exports = function () {
 
     } );
 
-    QUnit.asyncTest( 'Image.isGreyScale color image', function () {
+    QUnit.asyncTest( 'Image.isGreyScale color image', 1, function () {
 
 
         var test = function ( img ) {


### PR DESCRIPTION
compiler traverse nodes making sure we follow multiple output, thus taking precedence over order of node inside the node graph, making impossible optimisation like reuse of temp variable implicitely