### PR TITLE
A few necessary changes for our use case

### DIFF
--- a/sources/osgDB/Input.js
+++ b/sources/osgDB/Input.js
@@ -108,7 +108,7 @@ Input.prototype = {
         if ( typeof this._defaultOptions.prefixURL === 'string' &&
             this._defaultOptions.prefixURL.length > 0 ) {
 
-            if(url.indexOf(this._defaultOptions.prefixURL) === 0) {
+            if ( url.indexOf( this._defaultOptions.prefixURL ) === 0 ) {
                 return url;
             }
 
@@ -175,7 +175,6 @@ Input.prototype = {
         // crossOrigin does not work for inline data image
         var isInlineImage = ( url.substring( 0, checkInlineImage.length ) === checkInlineImage );
         var img = new window.Image();
-        img.crossOrigin = "Anonymous";
         img.onerror = function () {
             Notify.warn( 'warning use white texture as fallback instead of ' + url );
             image.setImage( Input.imageFallback );
@@ -415,8 +414,8 @@ Input.prototype = {
 
         var url = vb.File;
         var defer = P.defer();
-        if(options.rewriteFileUrl) {
-            url = options.rewriteFileUrl(url)
+        if ( options.rewriteBinaryArrayURL ) {
+            url = options.rewriteBinaryArrayURL( url );
         }
 
         this.readBinaryArrayURL( url ).then( function ( array ) {

--- a/sources/osgDB/Input.js
+++ b/sources/osgDB/Input.js
@@ -108,6 +108,10 @@ Input.prototype = {
         if ( typeof this._defaultOptions.prefixURL === 'string' &&
             this._defaultOptions.prefixURL.length > 0 ) {
 
+            if(url.indexOf(this._defaultOptions.prefixURL) === 0) {
+                return url;
+            }
+
             return this._defaultOptions.prefixURL + url;
         }
 
@@ -171,6 +175,7 @@ Input.prototype = {
         // crossOrigin does not work for inline data image
         var isInlineImage = ( url.substring( 0, checkInlineImage.length ) === checkInlineImage );
         var img = new window.Image();
+        img.crossOrigin = "Anonymous";
         img.onerror = function () {
             Notify.warn( 'warning use white texture as fallback instead of ' + url );
             image.setImage( Input.imageFallback );
@@ -406,10 +411,14 @@ Input.prototype = {
         if ( options === undefined )
             options = this.getOptions();
         if ( options.initializeBufferArray )
-            return options.initializeBufferArray.call( this, vb, type, buf );
+            return options.initializeBufferArray.call( this, vb, type, buf, options );
 
         var url = vb.File;
         var defer = P.defer();
+        if(options.rewriteFileUrl) {
+            url = options.rewriteFileUrl(url)
+        }
+
         this.readBinaryArrayURL( url ).then( function ( array ) {
 
             var typedArray;

--- a/sources/osgDB/Options.js
+++ b/sources/osgDB/Options.js
@@ -22,6 +22,10 @@ var defaultOptions = {
     // the function will be execute in the context of Input, see Input:readBinaryArrayURL
     readBinaryArrayURL: undefined,
 
+    // rewrite a binary array URL, useful if you need to prefix or suffix the URLs
+    // with some domain or specific paramters like credentials
+    rewriteBinaryArrayURL: undefined,
+
     imageLoadingUsePromise: true, // use promise to load image instead of returning Image
     imageOnload: undefined, // use callback when loading an image
     imageCrossOrigin: undefined // use callback when loading an image


### PR DESCRIPTION
- We needed to be able to rewrite the name of the file on the fly
- computeURL was adding the automatically created prefix to an already complete URL we passed using the options.readImageURL
- We img.crossOrigin = "Anonymous"; as we load cross origin images