### PR TITLE
Fix for uniforms declared as arrays

### DIFF
--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -216,15 +216,16 @@ Program.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( GLO
     },
 
     cacheUniformList: function ( gl, str ) {
-        var r = str.match( /uniform\s+\w+\s+\w+/g );
+        var r = str.match( /uniform\s+\w+\s+\w+((\s)?\[(.*?)\])?/g );
         var map = this._uniformsCache;
         if ( r !== null ) {
             for ( var i = 0, l = r.length; i < l; i++ ) {
                 var uniform = r[ i ].match( /uniform\s+\w+\s+(\w+)/ )[ 1 ];
+                var uniformName = r[ i ].match( /uniform\s+\w+\s+(\w+((\s)?\[(.*?)\])?)/ )[ 1 ];
                 var location = gl.getUniformLocation( this._program, uniform );
                 if ( location !== undefined && location !== null ) {
-                    if ( map[ uniform ] === undefined ) {
-                        map[ uniform ] = location;
+                    if ( map[ uniformName ] === undefined ) {
+                        map[ uniformName ] = location;
                         this._uniformsCache.dirty();
                     }
                 }

--- a/sources/osg/Uniform.js
+++ b/sources/osg/Uniform.js
@@ -65,7 +65,7 @@ Uniform.prototype = {
     // the setFloat/setVecX/setMatrixX will be copied to the
     // internal array. Consider using this function as an optimization
     // to avoid copy. It's possible inside StateAttribute code but it's
-    // safer to not do that in users code unless you what you are doing
+    // safer to not do that in users code unless you know what you are doing
     setInternalArray: function ( array ) {
         this._data = array;
     },


### PR DESCRIPTION
Uniforms declared like this:
`uniform float myarray[10];` or 
`uniform float myarray [10]; //note blank space before [ ` 
were not working.