### PR TITLE
Cleans osgNameSpace code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -277,22 +277,6 @@ var gruntTasks = {};
     };
 } )();
 
-var generateVersionFile = function () {
-    var pkg = JSON.parse( fs.readFileSync( 'package.json' ) );
-    var content = [
-        'define( [], function () {',
-        '    return {',
-        '        name: \'' + pkg.name + '\',',
-        '        version: \'' + pkg.version + '\',',
-        '        author: \'' + pkg.author + '\'',
-        '    };',
-        '} );',
-        ''
-
-    ];
-    fs.writeFileSync( path.join( SOURCE_PATH, 'version.js' ), content.join( '\n' ) );
-};
-
 // ## Clean
 //
 ( function () {
@@ -497,10 +481,6 @@ module.exports = function ( grunt ) {
     grunt.initConfig( extend( {
         pkg: grunt.file.readJSON( 'package.json' )
     }, gruntTasks ) );
-
-
-    generateVersionFile();
-
 
     // grunt.event.on('qunit.testStart', function (name) {
     //     grunt.log.ok("Running test: " + name);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "version": "0.2.5",
   "contributors": [
     "Tuan.kuranes <tuan.kuranes@gmail.com>",
-    "Matt Fontaine <tehqin@gmail.com>"
+    "Matt Fontaine <tehqin@gmail.com>",
+    "Stephane Ginier <stephane.ginier@gmail.com>"
   ],
   "dependencies": {
     "eslint": "^1.3.1",
@@ -29,6 +30,7 @@
     "grunt-webpack": "^1.0.8",
     "hammerjs": "^2.0.4",
     "jquery": "^2.1.3",
+    "json-loader": "^0.5.4",
     "leapjs": "^0.6.4",
     "path": "^0.11.14",
     "raw-loader": "^0.5.1",

--- a/sources/osgNameSpace.js
+++ b/sources/osgNameSpace.js
@@ -1,3 +1,9 @@
 'use strict';
-var version = require( 'version' );
-module.exports = version;
+
+var pkg = require( 'json!../package.json' );
+
+module.exports = {
+    name: pkg.name,
+    version: pkg.version,
+    author: pkg.author
+};


### PR DESCRIPTION
the require( 'version' ) was completely useless as : 
- the file doesn't exist (so the require always failed and returned undefined cf. examples where the version simply doesn't exist)
- the whole osgNameSpace file was overriden by the grunt build
