### PR TITLE
Fixes intersection visitor camera

### DIFF
--- a/sources/osg/Options.js
+++ b/sources/osg/Options.js
@@ -33,13 +33,13 @@ Options.prototype = {
 
     getBoolean: function ( key ) {
         var val = this.getString( key );
-        if ( val ) return Boolean( JSON.parse( val ) );
+        if ( val ) return ( val !== 'false' && val !== '0' );
         return undefined;
     },
 
     getNumber: function ( key ) {
         var val = this[ key ];
-        if ( val ) return Number( JSON.parse( val ) );
+        if ( val ) return Number( val );
         return undefined;
     },
 

--- a/sources/osgUtil/IntersectionVisitor.js
+++ b/sources/osgUtil/IntersectionVisitor.js
@@ -11,10 +11,12 @@ var IntersectionVisitor = function () {
     // We could need to use a stack of intersectors in case we want
     // to use several intersectors. Right now we use only one.
     this._intersector = undefined;
-    this._projectionStack = [];
-    this._modelStack = [];
-    this._viewStack = [];
-    this._windowStack = [];
+    this._projectionStack = [ Matrix.identity ];
+    this._modelStack = [ Matrix.identity ];
+    this._viewStack = [ Matrix.identity ];
+    this._windowStack = [ Matrix.identity ];
+
+    this.reset();
 };
 
 IntersectionVisitor.prototype = MACROUTILS.objectInherit( NodeVisitor.prototype, {

--- a/sources/osgUtil/NodeGizmo.js
+++ b/sources/osgUtil/NodeGizmo.js
@@ -161,6 +161,7 @@ var NodeGizmo = function ( viewer ) {
 
 // picking masks
 NodeGizmo.NO_PICK = 1 << 0;
+
 NodeGizmo.PICK_ARC_X = 1 << 1;
 NodeGizmo.PICK_ARC_Y = 1 << 2;
 NodeGizmo.PICK_ARC_Z = 1 << 3;
@@ -172,6 +173,8 @@ NodeGizmo.PICK_ARROW_Z = 1 << 6;
 NodeGizmo.PICK_PLANE_X = 1 << 7;
 NodeGizmo.PICK_PLANE_Y = 1 << 8;
 NodeGizmo.PICK_PLANE_Z = 1 << 9;
+
+NodeGizmo.NO_FULL_CIRCLE = 1 << 10; // don't display the full non pickable circle (visual cue)
 
 NodeGizmo.PICK_ARC = NodeGizmo.PICK_ARC_X | NodeGizmo.PICK_ARC_Y | NodeGizmo.PICK_ARC_Z;
 NodeGizmo.PICK_ARROW = NodeGizmo.PICK_ARROW_X | NodeGizmo.PICK_ARROW_Y | NodeGizmo.PICK_ARROW_Z;
@@ -294,6 +297,7 @@ NodeGizmo.prototype = MACROUTILS.objectInherit( MatrixTransform.prototype, {
 
         // children 0 is full arc
         var rotChildren = this._rotateNode.getChildren();
+        rotChildren[ 0 ].setNodeMask( mask & NodeGizmo.NO_FULL_CIRCLE ? 0x0 : NodeGizmo.NO_PICK );
         rotChildren[ 1 ].setNodeMask( mask & NodeGizmo.PICK_ARC_X ? NodeGizmo.PICK_ARC_X : 0x0 );
         rotChildren[ 2 ].setNodeMask( mask & NodeGizmo.PICK_ARC_Y ? NodeGizmo.PICK_ARC_Y : 0x0 );
         rotChildren[ 3 ].setNodeMask( mask & NodeGizmo.PICK_ARC_Z ? NodeGizmo.PICK_ARC_Z : 0x0 );

--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -19,10 +19,10 @@ var OptionsURL = ( function () {
     ( function ( options ) {
         var vars = [],
             hash;
-        var indexOptions = window.location.href.indexOf( '?' );
-        if ( indexOptions < 0 ) return;
+        if ( !window.location.search ) return;
 
-        var hashes = window.location.href.slice( indexOptions + 1 ).split( '&' );
+        // slice(1) to remove leading '?'
+        var hashes = window.location.search.slice( 1 ).split( '&' );
         for ( var i = 0; i < hashes.length; i++ ) {
             hash = hashes[ i ].split( '=' );
             var element = hash[ 0 ];


### PR DESCRIPTION
- reset the matrix stack if we create a new visitor
- handles the case where we use the intersection visitor starting with a non-camera node
 in that case, the first camera encountered was considered as absolute and it discarded the
 model matrices (although the camera was relative)