### PR TITLE
Removes epsilon check when changing min distance orbitManipulator

### DIFF
--- a/sources/osgGA/OrbitManipulator.js
+++ b/sources/osgGA/OrbitManipulator.js
@@ -237,7 +237,7 @@ OrbitManipulator.prototype = MACROUTILS.objectInherit( Manipulator.prototype, {
     },
 
     setMinDistance: function ( d ) {
-        this._minDistance = Math.max( 1e-4, d );
+        this._minDistance = d;
     },
     getMinDistance: function () {
         return this._minDistance;


### PR DESCRIPTION
Not sure why there were an epsilon check in the setMinDistance.