### PR TITLE
[D3D-2515] shadow ps must return 0 when unlighted

### DIFF
--- a/sources/osgShadow/shaders/shadowsReceiveMain.glsl
+++ b/sources/osgShadow/shaders/shadowsReceiveMain.glsl
@@ -1,6 +1,6 @@
 
     if (!lighted)
-        return 1.;
+        return 0.;
 
     if (depthRange.x == depthRange.y)
         return 1.;


### PR DESCRIPTION
When a light is not ligthing a fragment we optimize by not computing
shadow (and avoid any acne shadow on those surface)

But we returned 1.0 which means "no shadow" which is not consistent
shadow receive function. (in fact it is "shadowed")