### PR TITLE
Adds yUp normal flip support to the glTF loader

### DIFF
--- a/examples/pbr/main.js
+++ b/examples/pbr/main.js
@@ -175,7 +175,7 @@
             environmentType: 'cubemapSeamless',
             brightness: 1.0,
             normalAA: Boolean( optionsURL.normalAA === undefined ? true : optionsURL.normalAA ),
-            flipY: true,
+            flipY: false,
             specularPeak: Boolean( optionsURL.specularPeak === undefined ? true : optionsURL.specularPeak ),
             occlusionHorizon: Boolean( optionsURL.occlusionHorizon === undefined ? true : optionsURL.occlusionHorizon ),
             cameraPreset: optionsURL.camera ? Object.keys( CameraPresets )[ optionsURL.camera ] : 'CameraCenter',

--- a/examples/pbr/shaders/pbrReferenceFragment.glsl
+++ b/examples/pbr/shaders/pbrReferenceFragment.glsl
@@ -110,7 +110,7 @@ vec3 computeNormalFromTangentSpaceNormalMap(const in vec4 tangent, const in vec3
     if (length(tangent.xyz) != 0.0) {
         tang = normalize(tangent.xyz);
     }
-    vec3 B = -tangent.w * cross(normal, tang);
+    vec3 B = tangent.w * cross(normal, tang);
     vec3 outnormal = texnormal.x*tang + texnormal.y*B + texnormal.z*normal;
     return normalize(outnormal);
 }

--- a/sources/osgPlugins/ReaderWriterGLTF.js
+++ b/sources/osgPlugins/ReaderWriterGLTF.js
@@ -425,6 +425,7 @@ GLTFLoader.prototype = {
     createTextureAndSetAttrib: function ( glTFTextureId, osgStateSet, location, uniform ) {
 
         var defer = Promise.defer();
+        if ( !glTFTextureId ) return defer.resolve();
 
         var texture = new Texture();
 
@@ -445,6 +446,9 @@ GLTFLoader.prototype = {
 
             texture.setImage( data, GLTFLoader.TEXTURE_FORMAT[ glTFTexture.format ] );
             texture.setFlipY( glTFTexture.flipY );
+            var extras = glTFTexture.extras;
+            if ( extras )
+                osgStateSet.addUniform( Uniform.createInt1( extras.yUp ? 0 : 1, 'uFlipNormalY' ) );
 
             osgStateSet.setTextureAttributeAndModes( location, texture );
 
@@ -1071,9 +1075,9 @@ GLTFLoader.prototype = {
         var self = this;
 
         this.init();
-        this._preloaded = options.preloaded;
         this._files = files;
 
+        this._preloaded = options ? options.preloaded : null;
         if ( this._preloaded )
             this.preloadFiles( files );
 


### PR DESCRIPTION
This commit fixes some glTF loading issues and add normal Y-flipping support.

The line:
`vec3 B = -tangent.w * cross(normal, tang);`
seemed to be correct for left-handed coordinate systems.