### PR TITLE
[#D3D-270] Fixes shadow shader non uniform flow derivatives usage

### DIFF
--- a/sources/osg/WebGLCaps.js
+++ b/sources/osg/WebGLCaps.js
@@ -190,21 +190,6 @@ WebGLCaps.prototype = {
     // inevitable bugs per platform (browser/OS/GPU)
     initBugDB: function () {
 
-        var p = this._webGLPlatforms;
-        var ext = this._webGLParameters;
-
-        // derivatives gives strange results on Shadow Shaders
-        if ( p.Apple ) {
-
-            if ( !ext.UNMASKED_VENDOR_WEBGL || ext.UNMASKED_VENDOR_WEBGL.indexOf( 'Intel' ) !== -1 ) {
-                // bug is on INTEL GPU on APPLE
-                // we disable the ext on Apple if we cannot get GPU info
-                this._bugsDB[ 'OES_standard_derivatives' ] = true;
-
-            }
-
-        }
-
     },
     initPlatformSupport: function () {
 

--- a/sources/osgShadow/shaders/shadowsReceiveMain.glsl
+++ b/sources/osgShadow/shaders/shadowsReceiveMain.glsl
@@ -1,113 +1,140 @@
 
-    if (!lighted)
-        return 0.;
+// 0 for early out
+bool earlyOut = false;
 
-    if (depthRange.x == depthRange.y)
-        return 1.;
+// Calculate shadow amount
+float shadow = 1.0;
 
-    vec4 shadowVertexEye = shadowViewMatrix *  vec4(vertexWorld, 1.0);
-    float shadowReceiverZ =  - shadowVertexEye.z;
+if(!lighted) {
+    shadow = 0.0;
+    earlyOut = true;
+}
 
-    if( shadowReceiverZ < 0.0)
-        return 1.0; // notably behind camera
+if (depthRange.x == depthRange.y) {
+    earlyOut = true;
+}
 
-    vec4 shadowVertexProjected = shadowProjectionMatrix * shadowVertexEye;
-    if (shadowVertexProjected.w < 0.0)
-        return 1.0; // notably behind camera
+vec4 shadowVertexEye;
+float shadowReceiverZ = 0.0;
+vec4 shadowVertexProjected;
+vec2 shadowUV;
 
-    vec2 shadowUV;
+if(!earlyOut) {
 
-    shadowUV.xy = shadowVertexProjected.xy / shadowVertexProjected.w;
-    shadowUV.xy = shadowUV.xy * 0.5 + 0.5;// mad like
+    shadowVertexEye=  shadowViewMatrix *  vec4(vertexWorld, 1.0);
+    shadowReceiverZ=  - shadowVertexEye.z;
+    shadowVertexProjected = shadowProjectionMatrix * shadowVertexEye;
 
-    bool outFrustum = any(bvec4 ( shadowUV.x > 1., shadowUV.x < 0., shadowUV.y > 1., shadowUV.y < 0. ));
-    if (outFrustum )
-        return 1.0;// limits of light frustum
-    // most precision near 0, make sure we are near 0 and in [0,1]
-    shadowReceiverZ =  (shadowReceiverZ - depthRange.x)* depthRange.w;
+    if (shadowVertexProjected.w < 0.0) {
+        earlyOut = true; // notably behind camera
+    }
+      
+    if (!earlyOut) {
+        shadowUV.xy = shadowVertexProjected.xy / shadowVertexProjected.w;
+        shadowUV.xy = shadowUV.xy * 0.5 + 0.5;// mad like
 
-    // depth bias: fighting shadow acne (depth imprecsion z-fighting)
-    float shadowBias = 0.0;
-    // cosTheta is dot( n, l ), clamped between 0 and 1
-    //float shadowBias = 0.005*tan(acos(N_Dot_L));
-    // same but 4 cycles instead of 15
-    shadowBias += 0.05 *  sqrt( 1. -  N_Dot_L*N_Dot_L) / clamp(N_Dot_L, 0.0005,  1.0);
+        if(any(bvec4 ( shadowUV.x > 1., shadowUV.x < 0., shadowUV.y > 1., shadowUV.y < 0.))) {
+            earlyOut = true;// limits of light frustum
+        }
+          
+        // most precision near 0, make sure we are near 0 and in [0,1]
+        shadowReceiverZ =  (shadowReceiverZ - depthRange.x)* depthRange.w;
 
-    //That makes sure that plane perpendicular to light doesn't flicker due to
-    //selfshadowing and 1 = dot(Normal, Light) using a min bias
-    shadowBias = clamp(shadowBias, 0.00005,  bias);
+        if(shadowReceiverZ < 0.0) {
+            earlyOut = true; // notably behind camera
+        }
+          
+    }
+      
+}
 
-    // shadowZ must be clamped to [0,1]
-    // otherwise it's not comparable to
-    // shadow caster depth map
-    // which is clamped to [0,1]
-    // Not doing that makes ALL shadowReceiver > 1.0 black
-    // because they ALL becomes behind any point in Caster depth map
-    shadowReceiverZ = clamp(shadowReceiverZ, 0., 1. - shadowBias);
 
-    shadowReceiverZ -= shadowBias;
+#if defined( _PCF )
 
-    // Now computes Shadow
+// pcf pbias to add on offset
+vec2 shadowBiasPCF = vec2(0.);
 
-    // Calculate shadow amount
-    float shadow = 1.0;
+#ifdef GL_OES_standard_derivatives
 
-    // return 0.0 for black;
-    // return 1.0 for light;
+shadowBiasPCF.x = clamp(dFdx(shadowReceiverZ)* shadowMapSize.z, -1.0, 1.0 );
+shadowBiasPCF.y = clamp(dFdy(shadowReceiverZ)* shadowMapSize.w, -1.0, 1.0 );
+
+#endif
+#endif
+
+// now that derivatives is done
+// and we don't access any mipmapped/texgrad texture
+// we can early out
+// see http://teknicool.tumblr.com/post/77263472964/glsl-dynamic-branching-and-texture-samplers
+if (earlyOut) return shadow;
+
+// depth bias: fighting shadow acne (depth imprecsion z-fighting)
+float shadowBias = 0.0;
+// cosTheta is dot( n, l ), clamped between 0 and 1
+//float shadowBias = 0.005*tan(acos(N_Dot_L));
+// same but 4 cycles instead of 15
+shadowBias += 0.05 *  sqrt( 1. -  N_Dot_L*N_Dot_L) / clamp(N_Dot_L, 0.0005,  1.0);
+
+//That makes sure that plane perpendicular to light doesn't flicker due to
+//selfshadowing and 1 = dot(Normal, Light) using a min bias
+shadowBias = clamp(shadowBias, 0.00005,  bias);
+
+// shadowZ must be clamped to [0,1]
+// otherwise it's not comparable to
+// shadow caster depth map
+// which is clamped to [0,1]
+// Not doing that makes ALL shadowReceiver > 1.0 black
+// because they ALL becomes behind any point in Caster depth map
+shadowReceiverZ = clamp(shadowReceiverZ, 0., 1. - shadowBias);
+
+shadowReceiverZ -= shadowBias;
+
+// Now computes Shadow
+
 
 #ifdef _NONE
 
-    float shadowDepth = getSingleFloatFromTex(tex, shadowUV.xy);
-    // shadowReceiverZ : receiver depth in light view
-    // shadowDepth : caster depth in light view
-    // receiver is shadowed if its depth is superior to the caster
-    shadow = ( shadowReceiverZ > shadowDepth ) ? 0.0 : 1.0;
+float shadowDepth = getSingleFloatFromTex(tex, shadowUV.xy);
+// shadowReceiverZ : receiver depth in light view
+// shadowDepth : caster depth in light view
+// receiver is shadowed if its depth is superior to the caster
+shadow = ( shadowReceiverZ > shadowDepth ) ? 0.0 : 1.0;
 
 #elif defined( _PCF )
-    // pcf pbias to add on offset
-    vec2 shadowBiasPCF = vec2(0.);
 
 
-// looks like derivative is broken on some mac + intel cg ...
-#ifdef GL_OES_standard_derivatives
-
-    shadowBiasPCF.x = clamp(dFdx(shadowReceiverZ)* shadowMapSize.z, -1.0, 1.0 );
-    shadowBiasPCF.y = clamp(dFdy(shadowReceiverZ)* shadowMapSize.w, -1.0, 1.0 );
-    
-#endif
-
-
-    shadow = getShadowPCF(tex, shadowMapSize, shadowUV, shadowReceiverZ, shadowBiasPCF);
+shadow = getShadowPCF(tex, shadowMapSize, shadowUV, shadowReceiverZ, shadowBiasPCF);
 
 #elif defined( _ESM )
 
-    shadow = fetchESM(tex, shadowMapSize, shadowUV, shadowReceiverZ, exponent0, exponent1);
+shadow = fetchESM(tex, shadowMapSize, shadowUV, shadowReceiverZ, exponent0, exponent1);
 
 #elif  defined( _VSM )
 
-    vec2 moments = getDoubleFloatFromTex(tex, shadowUV.xy);
-    shadow = chebyshevUpperBound(moments, shadowReceiverZ, epsilonVSM);
+vec2 moments = getDoubleFloatFromTex(tex, shadowUV.xy);
+shadow = chebyshevUpperBound(moments, shadowReceiverZ, epsilonVSM);
 
 #elif  defined( _EVSM )
 
-    vec4 occluder = getQuadFloatFromTex(tex, shadowUV.xy);
-    vec2 exponents = vec2(exponent0, exponent1);
-    vec2 warpedDepth = warpDepth(shadowReceiverZ, exponents);
+vec4 occluder = getQuadFloatFromTex(tex, shadowUV.xy);
+vec2 exponents = vec2(exponent0, exponent1);
+vec2 warpedDepth = warpDepth(shadowReceiverZ, exponents);
 
-    float derivationEVSM = epsilonVSM;
-    // Derivative of warping at depth
-    vec2 depthScale = derivationEVSM * exponents * warpedDepth;
-    vec2 minVariance = depthScale * depthScale;
+float derivationEVSM = epsilonVSM;
+// Derivative of warping at depth
+vec2 depthScale = derivationEVSM * exponents * warpedDepth;
+vec2 minVariance = depthScale * depthScale;
 
-    float epsilonEVSM = -epsilonVSM;
+float epsilonEVSM = -epsilonVSM;
 
-    // Compute the upper bounds of the visibility function both for x and y
-    float posContrib = chebyshevUpperBound(occluder.xz, -warpedDepth.x, minVariance.x);
-    float negContrib = chebyshevUpperBound(occluder.yw, warpedDepth.y, minVariance.y);
+// Compute the upper bounds of the visibility function both for x and y
+float posContrib = chebyshevUpperBound(occluder.xz, -warpedDepth.x, minVariance.x);
+float negContrib = chebyshevUpperBound(occluder.yw, warpedDepth.y, minVariance.y);
 
-    shadow = min(posContrib, negContrib);
+shadow = min(posContrib, negContrib);
 
 #endif
 
 
-    return shadow;
+return shadow;
+


### PR DESCRIPTION
Removed using derivating inside a branch as it makes for undefined behavior
So the early return in the shadowmaping code in now done after
derivatives computations
see http://teknicool.tumblr.com/post/77263472964/glsl-dynamic-branching-and-texture-samplers