### PR TITLE
Removes inline webpack loaders shortcuts

### DIFF
--- a/sources/osgNameSpace.js
+++ b/sources/osgNameSpace.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var pkg = require( 'json!../package.json' );
+var pkg = require( 'json-loader!../package.json' );
 
 module.exports = {
     name: pkg.name,


### PR DESCRIPTION
Webpack 2 stopped supporting the '-loader' shortcut. When trying to require a source package of osgjs in a project using wepback 2, the build currently fails. This PR fixes that.