### PR TITLE
Resolves video event if it is already ready

### DIFF
--- a/sources/osg/ImageStream.js
+++ b/sources/osg/ImageStream.js
@@ -54,7 +54,9 @@ ImageStream.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit(
 
         if ( !this._canPlayDefered ) {
             this._canPlayDefered = P.defer();
-            this._imageObject.addEventListener( 'canplaythrough', this._canPlayDefered.resolve.bind( this._canPlayDefered, this ), true );
+            // resolve directly if the event is already fired
+            if ( this._imageObject.readyState > 3 ) this._canPlayDefered.resolve( this );
+            else this._imageObject.addEventListener( 'canplaythrough', this._canPlayDefered.resolve.bind( this._canPlayDefered, this ), true );
         }
 
         return this._canPlayDefered.promise;


### PR DESCRIPTION
Can prevent issue such as http://stackoverflow.com/questions/10235919/the-canplay-canplaythrough-events-for-an-html5-video-are-not-called-on-firefox