### PR TITLE
Cleans a few stuffs in polytope code

### DIFF
--- a/sources/osg/Plane.js
+++ b/sources/osg/Plane.js
@@ -63,7 +63,7 @@ var Plane = MACROUTILS.objectInherit( vec4, {
 
     /* using the plane equation, compute distance to plane of a point*/
     distanceToPlane: function ( plane, position ) {
-        return plane[ 0 ] * position[ 0 ] + plane[ 1 ] * position[ 1 ] + plane[ 2 ] * position[ 2 ] + plane[ 3 ];
+        return vec3.dot( plane, position ) + plane[ 3 ];
     },
 
 

--- a/sources/osg/Viewport.js
+++ b/sources/osg/Viewport.js
@@ -52,12 +52,13 @@ Viewport.prototype = MACROUTILS.objectLibraryClass( MACROUTILS.objectInherit( St
     computeWindowMatrix: ( function () {
         var translate = mat4.create();
         var scale = mat4.create();
-        var unitVec = vec3.fromValues( 1.0, 1.0, 1.0 );
+        var tmpVec = vec3.create();
+
         return function ( destination ) {
             // res = Matrix offset * Matrix scale * Matrix translate
-            mat4.fromTranslation( translate, unitVec );
+            mat4.fromTranslation( translate, vec3.ONE );
             mat4.fromScaling( scale, [ 0.5 * this._width, 0.5 * this._height, 0.5 ] );
-            var offset = mat4.fromTranslation( destination, vec3.fromValues( this._x, this._y, 0.0 ) );
+            var offset = mat4.fromTranslation( destination, vec3.set( tmpVec, this._x, this._y, 0.0 ) );
 
             return mat4.mul( offset, offset, mat4.mul( scale, scale, translate ) );
 


### PR DESCRIPTION
Reduce vector allocations.
Fixes the buggy use case when there is no matrix transform in the picking path (uninitialized _iPolytope/_iReferencePlane)
Adds the cullingActive check for node intersection (like the segmentIntersector)
