### PR TITLE
Removes uniform gl method cache

### DIFF
--- a/sources/osg/Uniform.js
+++ b/sources/osg/Uniform.js
@@ -8,7 +8,6 @@ var Uniform = function ( name ) {
     this._data = undefined;
     this._transpose = false;
     this._glCall = '';
-    this._cache = undefined;
     this._name = name;
     this._type = undefined;
     this._isMatrix = false;
@@ -34,13 +33,10 @@ Uniform.prototype = {
 
     apply: function UniformApply( gl, location ) {
 
-        if ( !this._cache )
-            this._cache = gl[ this._glCall ];
-
         if ( this._isMatrix )
-            this._cache.call( gl, location, this._transpose, this._data );
+            gl[ this._glCall ]( location, this._transpose, this._data );
         else
-            this._cache.call( gl, location, this._data );
+            gl[ this._glCall ]( location, this._data );
     },
 
     // no type checking, so array should be valid


### PR DESCRIPTION
Firefox android on samsung S6 doesn't allow js "function().call(this, ...args...)"
on webglcontextRenderingObject