### PR TITLE
Renames compiler shader functions

### DIFF
--- a/sources/osgShader/Compiler.js
+++ b/sources/osgShader/Compiler.js
@@ -50,6 +50,16 @@ var Compiler = function ( attributes, textureAttributes, shaderProcessor ) {
 
 Compiler.prototype = MACROUTILS.extend( {}, CompilerVertex, CompilerFragment, {
 
+    createFragmentShader: function () {
+        this._fragmentShaderMode = true;
+        return this._createFragmentShader();
+    },
+
+    createVertexShader: function () {
+        this._fragmentShaderMode = false;
+        return this._createVertexShader();
+    },
+
     getOrCreateProjectionMatrix: function () {
         return this.getOrCreateUniform( 'mat4', 'uProjectionMatrix' );
     },

--- a/sources/osgShader/CompilerFragment.js
+++ b/sources/osgShader/CompilerFragment.js
@@ -6,10 +6,7 @@ var MACROUTILS = require( 'osg/Utils' );
 
 var CompilerFragment = {
 
-    createFragmentShader: function () {
-
-        this._fragmentShaderMode = true;
-
+    _createFragmentShader: function () {
         // Call to specialised inhenrited shader Compiler
         var roots = this.createFragmentShaderGraph();
         var fname = this.getFragmentShaderName();
@@ -604,5 +601,20 @@ var CompilerFragment = {
         return texel;
     }
 };
+
+var wrapperFragmentOnly = function ( fn, name ) {
+    return function () {
+        if ( !this._fragmentShaderMode )
+            Notify.error( 'This function should not be called from vertex shader : ' + name );
+        return fn.apply( this, arguments );
+    };
+};
+
+var fns = window.Object.keys( CompilerFragment );
+var nbFunc = fns.length;
+for ( var i = 0; i < nbFunc; ++i ) {
+    var fnName = fns[ i ];
+    CompilerFragment[ fnName ] = wrapperFragmentOnly( CompilerFragment[ fnName ], fnName );
+}
 
 module.exports = CompilerFragment;

--- a/sources/osgShader/CompilerVertex.js
+++ b/sources/osgShader/CompilerVertex.js
@@ -4,10 +4,7 @@ var Notify = require( 'osg/notify' );
 
 var CompilerVertex = {
 
-    createVertexShader: function () {
-
-        this._fragmentShaderMode = false;
-
+    _createVertexShader: function () {
         // Call to specialised inhenrited shader Compiler
         var roots = this.declareVertexMain();
         var vname = this.getVertexShaderName();
@@ -411,5 +408,20 @@ var CompilerVertex = {
         return vecOut;
     }
 };
+
+var wrapperVertexOnly = function ( fn, name ) {
+    return function () {
+        if ( this._fragmentShaderMode )
+            Notify.error( 'This function should not be called from fragment shader : ' + name );
+        return fn.apply( this, arguments );
+    };
+};
+
+var fns = window.Object.keys( CompilerVertex );
+var nbFunc = fns.length;
+for ( var i = 0; i < nbFunc; ++i ) {
+    var fnName = fns[ i ];
+    CompilerVertex[ fnName ] = wrapperVertexOnly( CompilerVertex[ fnName ], fnName );
+}
 
 module.exports = CompilerVertex;


### PR DESCRIPTION
Some getOrCreate were just create. Also renamed a few functions.

As a side note :
In osgjs the separation between CompilerVertex and CompilerFragment is just implicit, they are part of the same Compiler class.

Maybe it'd be nice to have a system where some functions could *only* be called from certain shader stage.

For example it's confusing that `getOrCreateModelVertex`, `getOrCreateLocalVertex`, etc... (same for normal, tangent) should only be called from the vertex stage (in the fragment we query directly the varying).
Alternatively, functions named `getOrCreateFrontBlabla` shouldn't be called from CompilerVertex.
