### PR TITLE
Fixes spotlight wrong ndl earlyout

### DIFF
--- a/sources/osgShadow/shaders/shadowsReceiveMain.glsl
+++ b/sources/osgShadow/shaders/shadowsReceiveMain.glsl
@@ -29,11 +29,6 @@ if(!earlyOut) {
     shadowNormalEye =  shadowViewMatrix * normalFront;
     N_Dot_L = dot(shadowNormalEye.xyz, shadowLightDir);
 
-    if (N_Dot_L <= 0.0) {
-        shadow = 1.0;
-        earlyOut = true;
-    }
-
     if(!earlyOut) {
 
 #ifdef _NORMAL_OFFSET


### PR DESCRIPTION
Spotlight shadowmatrix isn't the same as the light matrix 
(it's an optimized frustum) so dot(normal,light) may not yeld the same result in some cases
( note that the test was redundant with the "lighted" boolean we get from actual light computation, so no big loss here. )