### PR TITLE
Fixes an edge case in orbitManipulator limits

### DIFF
--- a/sources/osgGA/OrbitManipulator.js
+++ b/sources/osgGA/OrbitManipulator.js
@@ -40,6 +40,9 @@ OrbitManipulator.ControllerList = [ 'StandardMouseKeyboard',
 ];
 
 var TWO_PI = 2 * Math.PI;
+var lowerOrEqual = function ( val, limit ) {
+    return val < limit + 0.00001;
+};
 
 /** @lends OrbitManipulator.prototype */
 OrbitManipulator.prototype = MACROUTILS.objectInherit( Manipulator.prototype, {
@@ -272,9 +275,9 @@ OrbitManipulator.prototype = MACROUTILS.objectInherit( Manipulator.prototype, {
                 if ( isOutsideLimit ) yaw = Math.abs( yaw - left ) > Math.abs( yaw - right ) ? right : left;
             }
 
-            if ( deltaYaw > 0.0 && previousYaw <= right && yaw > right ) {
+            if ( deltaYaw > 0.0 && lowerOrEqual( previousYaw, right ) && yaw > right ) {
                 yaw = right;
-            } else if ( deltaYaw < 0.0 && previousYaw >= left && yaw < left ) {
+            } else if ( deltaYaw < 0.0 && lowerOrEqual( left, previousYaw ) && yaw < left ) {
                 yaw = left;
             }
         }

--- a/tests/osgGA/OrbitManipulator.js
+++ b/tests/osgGA/OrbitManipulator.js
@@ -87,6 +87,10 @@ module.exports = function () {
         yaw = orbit._computeYaw( 2.01, -0.02, 2.0, 3.0 );
         assert.isOk( yaw === 2.0, 'Right left same quadrant / small inc outside range (left). Yaw is ' + yaw + ' and should be 2.0' );
 
+        //edge case when prev yaw is slightly over limit
+        yaw = orbit._computeYaw( 1.9198621771937627, 0.00296099990606308, 1.8500490071139892, 1.9198621771937625 );
+        assert.isOk( yaw === 1.9198621771937625, 'Right left same quadrant / small inc outside range (right, rounding issue on equal). Yaw is ' + yaw + ' and should be 1.9198621771937625' );
+
 
     } );
 


### PR DESCRIPTION
Fixes a case when the computer previousYaw is not exactly the same that was set on the previous frame.
this line https://github.com/cedricpinson/osgjs/blob/master/sources/osgGA/OrbitManipulator.js#L246

For example whenever we reach the limit (say 2.0), next frame the computed previousYaw could return 2.00000000001 which will make this test fail https://github.com/cedricpinson/osgjs/blob/master/sources/osgGA/OrbitManipulator.js#L275

This PR introduce a value comparison with an epsilon value to avoid this problem.