### PR TITLE
Clears the whole atlas at the same time

### DIFF
--- a/examples/shadowmap/main.js
+++ b/examples/shadowmap/main.js
@@ -620,7 +620,7 @@
             for (l = 0; l < this._lights.length; l++) this._lights[l].setEnabled(false);
 
             if (this._lights.length !== numLights) {
-                var lightScale = 1.0 / (numLights + 4);
+                var lightScale = 0.45 / (numLights + 4);
 
                 var group = this._viewer.getSceneData();
 
@@ -628,8 +628,11 @@
 
                 // remove all lights
                 while (l--) {
-                    this._lightAndShadowScene.removeShadowTechnique(this._shadowTechnique[l]);
-
+                    if (this._config.atlas) {
+                        this._shadowMapAtlas.removeShadowMap(this._shadowTechnique[l]);
+                    } else {
+                        this._lightAndShadowScene.removeShadowTechnique(this._shadowTechnique[l]);
+                    }
                     group.removeChild(this._lightsMatrix[l]);
                     group.removeChild(this._debugLights[l]);
                 }
@@ -714,7 +717,7 @@
                 var l = this._lights.length;
                 while (l--) {
                     var shadowSettings = this._shadowSettings[l];
-                    shadowSettings.setTextureType(texType);
+                    if (shadowSettings) shadowSettings.setTextureType(texType);
                 }
                 this._previousTextureType = this._config.textureType;
             }
@@ -726,7 +729,9 @@
             if (this._previousTextureSize !== mapsize) {
                 var l = this._lights.length;
                 while (l--) {
-                    this._shadowSettings[l].setTextureSize(mapsize);
+                    if (this._shadowSettings[l]) {
+                        this._shadowSettings[l].setTextureSize(mapsize);
+                    }
                 }
                 this._previousTextureSize = mapsize;
             }
@@ -748,6 +753,9 @@
          * with a single callback for all ui user changes
          */
         updateShadow: function() {
+            if (this._config.atlas && this._config.lightNum > 3) {
+                this._config.lightNum = 4;
+            }
             this.updateShadowStatic();
 
             this.updateLightsAmbient();
@@ -763,13 +771,16 @@
 
             var l, numLights;
             numLights = this._config.lightNum;
+
             l = numLights;
             while (l--) {
                 var shadowSettings = this._shadowSettings[l];
 
-                shadowSettings.bias = this._config.bias;
-                shadowSettings.normalBias = this._config.normalBias;
-                shadowSettings.kernelSizePCF = this._config.kernelSizePCF;
+                if (shadowSettings) {
+                    shadowSettings.bias = this._config.bias;
+                    shadowSettings.normalBias = this._config.normalBias;
+                    shadowSettings.kernelSizePCF = this._config.kernelSizePCF;
+                }
             }
 
             var shadowMap;
@@ -1126,6 +1137,7 @@
             var shadowMap;
             if (this._config.atlas) {
                 shadowMap = this._shadowMapAtlas.addLight(light);
+                //this._shadowMapAtlas.addShadowMap();
             } else {
                 // need to set lightSource rather than light pos
                 // as there is no link in Light to get current Matrix.
@@ -1206,7 +1218,7 @@
             this._config.camera = this._viewer.getCamera();
 
             var numLights = this._config.lightNum;
-            var lightScale = 1.0 / numLights - 1e-4;
+            var lightScale = 0.45 / numLights - 1e-4;
 
             var k;
             if (this._config.atlas) {

--- a/sources/osg/Camera.js
+++ b/sources/osg/Camera.js
@@ -158,7 +158,12 @@ MACROUTILS.createPrototypeNode(
                 this.renderOrder = order;
                 this.renderOrderNum = orderNum;
             },
-
+            getFrameBufferObject: function() {
+                return this.frameBufferObject;
+            },
+            setFrameBufferObject: function(fbo) {
+                this.frameBufferObject = fbo;
+            },
             detachAll: function() {
                 this._attachments = {};
 

--- a/sources/osg/RenderStage.js
+++ b/sources/osg/RenderStage.js
@@ -264,13 +264,6 @@ MACROUTILS.createPrototypeObject(
             }
             state.applyAttribute(this.viewport);
 
-            // fragment clipping
-            if (this.camera) {
-                var scissor =
-                    this.camera.getStateSet() && this.camera.getStateSet().getAttribute('Scissor');
-                if (scissor) state.applyAttribute(scissor);
-            }
-
             /*jshint bitwise: false */
             if (this.clearMask !== 0x0) {
                 if (this.clearMask & gl.COLOR_BUFFER_BIT) {

--- a/sources/osgShader/CompilerFragment.js
+++ b/sources/osgShader/CompilerFragment.js
@@ -338,7 +338,7 @@ var CompilerFragment = {
         return undefined;
     },
 
-    _getShadowFromLightNum: function(array, lightNum) {
+    _getShadowReceiveAttributeFromLightNum: function(array, lightNum) {
         // array is shadow textures or shadow receive attributes
         for (var i = 0; i < array.length; i++) {
             var shadow = array[i];
@@ -348,11 +348,22 @@ var CompilerFragment = {
         }
     },
 
-    getInputsFromShadow: function(shadowReceive, shadowTexture, lighted) {
+    _getShadowTextureFromLightNum: function(array, lightNum) {
+        // array is shadow textures or shadow receive attributes
+        for (var i = 0; i < array.length; i++) {
+            var shadow = array[i];
+            if (shadow && shadow.hasLightNumber(lightNum)) {
+                return shadow;
+            }
+        }
+    },
+
+    getInputsFromShadow: function(shadowReceive, shadowTexture, lighted, lightNum) {
         var shadowUniforms = shadowReceive.getOrCreateUniforms();
         var tUnit = this._shadowsTextures.indexOf(shadowTexture);
         var textureUniforms = shadowTexture.getOrCreateUniforms(tUnit);
 
+        var suffix = shadowReceive.getAtlas() ? '_' + lightNum : '';
         var inputs = {
             lighted: lighted,
             normalWorld: this.getOrCreateNormalizedFrontModelNormal(),
@@ -390,8 +401,8 @@ var CompilerFragment = {
 
     createShadowingLight: function(light, lighted) {
         var lightNum = light.getLightNumber();
-        var shadowTexture = this._getShadowFromLightNum(this._shadowsTextures, lightNum);
-        var shadowReceive = this._getShadowFromLightNum(this._shadows, lightNum);
+        var shadowTexture = this._getShadowTextureFromLightNum(this._shadowsTextures, lightNum);
+        var shadowReceive = this._getShadowReceiveAttributeFromLightNum(this._shadows, lightNum);
         if (!shadowTexture || !shadowReceive) return undefined;
 
         var inputs = this.getInputsFromShadow(shadowReceive, shadowTexture, lighted);

--- a/sources/osgShader/CompilerFragment.js
+++ b/sources/osgShader/CompilerFragment.js
@@ -369,15 +369,17 @@ var CompilerFragment = {
             normalWorld: this.getOrCreateNormalizedFrontModelNormal(),
             vertexWorld: this.getOrCreateVarying('vec3', 'vModelVertex'),
             shadowTexture: this.getOrCreateSampler('sampler2D', 'Texture' + tUnit),
-            shadowSize: this.getOrCreateUniform(textureUniforms.RenderSize),
-            shadowProjectionMatrix: this.getOrCreateUniform(textureUniforms.ProjectionMatrix),
-            shadowViewMatrix: this.getOrCreateUniform(textureUniforms.ViewMatrix),
-            shadowDepthRange: this.getOrCreateUniform(textureUniforms.DepthRange),
+            shadowSize: this.getOrCreateUniform(textureUniforms['RenderSize']),
+            shadowProjectionMatrix: this.getOrCreateUniform(
+                textureUniforms['ProjectionMatrix' + suffix]
+            ),
+            shadowViewMatrix: this.getOrCreateUniform(textureUniforms['ViewMatrix' + suffix]),
+            shadowDepthRange: this.getOrCreateUniform(textureUniforms['DepthRange' + suffix]),
             shadowBias: this.getOrCreateUniform(shadowUniforms.bias)
         };
 
         if (shadowReceive.getAtlas())
-            inputs.atlasSize = this.getOrCreateUniform(textureUniforms.MapSize);
+            inputs.atlasSize = this.getOrCreateUniform(textureUniforms['MapSize' + suffix]);
         if (shadowReceive.getNormalBias())
             inputs.normalBias = this.getOrCreateUniform(shadowUniforms.normalBias);
 
@@ -394,8 +396,8 @@ var CompilerFragment = {
     },
 
     hasLightShadow: function(lightNum) {
-        var shadowTexture = this._getShadowFromLightNum(this._shadowsTextures, lightNum);
-        var shadowReceive = this._getShadowFromLightNum(this._shadows, lightNum);
+        var shadowTexture = this._getShadowTextureFromLightNum(this._shadowsTextures, lightNum);
+        var shadowReceive = this._getShadowReceiveAttributeFromLightNum(this._shadows, lightNum);
         return !!shadowTexture && !!shadowReceive;
     },
 
@@ -405,7 +407,7 @@ var CompilerFragment = {
         var shadowReceive = this._getShadowReceiveAttributeFromLightNum(this._shadows, lightNum);
         if (!shadowTexture || !shadowReceive) return undefined;
 
-        var inputs = this.getInputsFromShadow(shadowReceive, shadowTexture, lighted);
+        var inputs = this.getInputsFromShadow(shadowReceive, shadowTexture, lighted, lightNum);
 
         var shadowedOutput = this.createVariable('float');
         var outputs = {

--- a/sources/osgShadow/ShadowMapAtlas.js
+++ b/sources/osgShadow/ShadowMapAtlas.js
@@ -1,14 +1,15 @@
 'use strict';
 var notify = require('osg/notify');
-var StateAttribute = require('osg/StateAttribute');
-var Texture = require('osg/Texture');
-var Uniform = require('osg/Uniform');
-var MACROUTILS = require('osg/Utils');
-var Scissor = require('osg/Scissor');
 var vec4 = require('osg/glMatrix').vec4;
+var Camera = require('osg/Camera');
+var MACROUTILS = require('osg/Utils');
 var ShadowTechnique = require('osgShadow/ShadowTechnique');
 var ShadowTextureAtlas = require('osgShadow/ShadowTextureAtlas');
 var ShadowMap = require('osgShadow/ShadowMap');
+var Texture = require('osg/Texture');
+var FrameBufferObject = require('osg/FrameBufferObject');
+var Uniform = require('osg/Uniform');
+var Viewport = require('osg/Viewport');
 
 /**
  *  ShadowMapAtlas provides an implementation of shadow textures.
@@ -51,6 +52,12 @@ var ShadowMapAtlas = function(settings) {
 
     this._numShadowWidth = this._textureSize / this._shadowMapSize;
     this._numShadowHeight = this._textureSize / this._shadowMapSize;
+
+    this._cameraClear = new Camera();
+    this._cameraClear.setName('shadowAtlasCameraClear');
+    this._cameraClear.setRenderOrder(Camera.PRE_RENDER, 0);
+    this._cameraClear.setClearColor(vec4.fromValues(1.0, 1.0, 1.0, 1.0));
+    this._cameraClear.setFrameBufferObject(new FrameBufferObject());
 };
 
 /** @lends ShadowMapAtlas.prototype */
@@ -72,8 +79,8 @@ MACROUTILS.createPrototypeObject(
             return false;
         },
         /**
-     * at which Texture unit number we start adding texture shadow
-     */
+         * at which Texture unit number we start adding texture shadow
+         */
         setTextureUnitBase: function(unitBase) {
             this._textureUnitBase = unitBase;
             this._textureUnit = unitBase;
@@ -84,7 +91,7 @@ MACROUTILS.createPrototypeObject(
         },
 
         /* Sets  shadowSettings
-     */
+        */
         setShadowSettings: function(shadowSettings) {
             if (!shadowSettings) return;
             this._shadowSettings = shadowSettings;
@@ -224,15 +231,13 @@ MACROUTILS.createPrototypeObject(
 
             this._lights.push(light);
             this._shadowSettings.setLight(light);
+
             var shadowMap = new ShadowMap(this._shadowSettings, this._texture);
             this._shadowMaps.push(shadowMap);
 
-            var mapSize = this._shadowMapSize;
-            var y = mapSize * (lightCount % this._numShadowWidth);
-            var x = mapSize * Math.floor(lightCount / this._numShadowHeight);
+            if (this._shadowedScene) shadowMap.setShadowedScene(this._shadowedScene);
 
-            shadowMap.setShadowedScene(this._shadowedScene);
-            this._viewportDimension.push(vec4.fromValues(x, y, mapSize, mapSize));
+            this.recomputeViewports();
 
             return shadowMap;
         },
@@ -251,36 +256,101 @@ MACROUTILS.createPrototypeObject(
             this._textureUnit = this._textureUnitBase;
             this._texture.setName('ShadowTexture' + this._textureUnit);
 
-            this._numShadowWidth = this._textureSize / this._shadowMapSize;
-            this._numShadowHeight = this._textureSize / this._shadowMapSize;
-
             var unifRenderSize = Uniform.createFloat2('RenderSize');
             this._texelSizeUniform = Uniform.createFloat1(1.0 / this._textureSize, 'texelSize');
             this._renderSize = unifRenderSize.getInternalArray();
             this._renderSize[0] = this._renderSize[1] = this._textureSize;
 
+            this.recomputeViewports();
             for (var i = 0, l = this._shadowMaps.length; i < l; i++) {
-                var mapSize = this._shadowMapSize;
-                var y = mapSize * (i % this._numShadowWidth);
-                var x = mapSize * Math.floor(i / this._numShadowHeight);
+                var shadowMap = this._shadowMaps[i];
 
-                this._viewportDimension[i] = vec4.fromValues(x, y, mapSize, mapSize);
-                this._shadowMaps[i].init(this._texture, i, this._textureUnitBase);
-                this._texture.setLightShadowMapSize(i, this._viewportDimension[i]);
-
-                var st = this._shadowMaps[i].getCamera().getOrCreateStateSet();
-                var scissor = new Scissor(x, y, mapSize, mapSize);
-                st.setAttributeAndModes(scissor, StateAttribute.ON | StateAttribute.OVERRIDE);
+                if (!this._shadowedScene)
+                    this._shadowedScene = shadowMap.getShadowedScene(this._shadowedScene);
+                if (this._shadowedScene) shadowMap.setShadowedScene(this._shadowedScene);
+                shadowMap.init(this._texture, i, this._textureUnitBase);
+                shadowMap.getCamera().setClearMask(0x0);
             }
         },
+
+        recomputeViewports: function() {
+            var numViews = this._shadowMaps.length;
+
+            var viewDivideY = numViews > 2 ? Math.sqrt(2 * Math.ceil(numViews / 2)) : numViews;
+            var viewDivideX = viewDivideY;
+
+            var mapSizeX = this._textureSize / viewDivideX;
+            var mapSizeY = this._textureSize / viewDivideY;
+
+            var numShadowWidth = this._textureSize / mapSizeX;
+            var numShadowHeight = this._textureSize / mapSizeY;
+
+            for (var i = 0; i < numViews; i++) {
+                var shadowMap = this._shadowMaps[i];
+
+                var x = mapSizeX * (i % numShadowWidth);
+                var y = mapSizeY * Math.floor(i / numShadowHeight);
+
+                if (this._viewportDimension.length <= i) {
+                    this._viewportDimension.push(vec4.fromValues(x, y, mapSizeX, mapSizeY));
+                } else {
+                    vec4.set(this._viewportDimension[i], x, y, mapSizeX, mapSizeY);
+                }
+
+                this._texture.setLightShadowMapSize(
+                    this._lights[i].getLightNumber(),
+                    this._viewportDimension[i]
+                );
+
+                if (this._viewportDimension.length <= i) {
+                    this._viewportDimension.push(vec4.fromValues(x, y, mapSizeX, mapSizeY));
+                } else {
+                    vec4.set(this._viewportDimension[i], x, y, mapSizeX, mapSizeY);
+                }
+
+                shadowMap.dirty();
+            }
+        },
+
         valid: function() {
             // checks
             return true;
         },
 
+        updateCameraClear: function() {
+            var camera = this._cameraClear;
+            var texture = this._texture;
+
+            if (camera && texture) {
+                var vp = camera.getViewport();
+
+                if (!vp) {
+                    vp = new Viewport();
+                    camera.setViewport(vp);
+                }
+
+                // if texture size changed update the camera rtt params
+                if (vp.width() !== texture.getWidth() || vp.height() !== texture.getHeight()) {
+                    camera.detachAll();
+
+                    camera.attachTexture(FrameBufferObject.COLOR_ATTACHMENT0, texture);
+                    camera.attachRenderBuffer(
+                        FrameBufferObject.DEPTH_ATTACHMENT,
+                        FrameBufferObject.DEPTH_COMPONENT16
+                    );
+                    camera.getViewport().setViewport(0, 0, texture.getWidth(), texture.getHeight());
+                }
+            }
+        },
+
         updateShadowTechnique: function(nv) {
+            this.updateCameraClear();
             for (var i = 0, l = this._shadowMaps.length; i < l; i++) {
-                this._shadowMaps[i].updateShadowTechnique(nv, this._viewportDimension[i]);
+                this._shadowMaps[i].updateShadowTechnique(
+                    nv,
+                    this._viewportDimension[i],
+                    this._cameraClear.getFrameBufferObject()
+                );
             }
         },
 
@@ -314,10 +384,56 @@ MACROUTILS.createPrototypeObject(
 
         // Defines the frustum from light param.
         //
-        cullShadowCasting: function(cullVisitor) {
+        cullShadowCasting: function(cullVisitor, bbox) {
+            this._cameraClear.accept(cullVisitor);
+
             for (var i = 0, l = this._shadowMaps.length; i < l; i++) {
-                this._shadowMaps[i].cullShadowCasting(cullVisitor);
+                this._shadowMaps[i].cullShadowCasting(cullVisitor, bbox);
             }
+        },
+
+        removeShadowMap: function(shadowMap) {
+            if (this._shadowMaps.length > 0) {
+                var idx = this._shadowMaps.indexOf(shadowMap);
+                if (idx !== -1) {
+                    if (this._shadowMaps[idx].valid()) {
+                        this._shadowMaps[idx].cleanSceneGraph(true);
+                    }
+                    this._shadowMaps.splice(idx, 1);
+
+                    var lightNumberArray = this._texture.getLightNumberArray();
+                    idx = lightNumberArray.indexOf(shadowMap.getLightNumber());
+                    if (idx !== -1) lightNumberArray.splice(idx, 1);
+
+                    var light = shadowMap.getLight();
+                    idx = this._lights.indexOf(light);
+                    if (idx !== -1) this._lights.splice(idx, 1);
+
+                    this.recomputeViewports();
+                }
+            }
+        },
+
+        addShadowMap: function(shadowMap) {
+            if (this._shadowMaps.length > 0) {
+                if (this._shadowMaps.indexOf(shadowMap) !== -1) return;
+            }
+
+            this._shadowMaps.push(shadowMap);
+
+            var light = shadowMap.getLight();
+            if (this._lights.indexOf(light) === -1) {
+                this._lights.push(light);
+            }
+
+            if (this._shadowedScene) shadowMap.setShadowedScene(this._shadowedScene);
+
+            var lightNumberArray = this._texture.getLightNumberArray();
+            if (lightNumberArray.indexOf(shadowMap.getLightNumber()) === -1) {
+                lightNumberArray.push(light.getLightNumber());
+            }
+
+            this.recomputeViewports();
         },
 
         cleanReceivingStateSet: function() {

--- a/sources/osgShadow/ShadowedScene.js
+++ b/sources/osgShadow/ShadowedScene.js
@@ -198,7 +198,6 @@ MACROUTILS.createPrototypeNode(
 
                     return;
                 }
-
                 var bbox = this._computeBoundsVisitor.getBoundingBox();
 
                 // HERE we get the shadowedScene Current World Matrix

--- a/tests/mockup/mockup.js
+++ b/tests/mockup/mockup.js
@@ -87,6 +87,7 @@ var createFakeRenderer = function() {
         createBuffer: function() {},
         deleteBuffer: function() {},
 
+        scissor: function() {},
         blendColor: function() {},
         enable: function() {},
         disable: function() {},


### PR DESCRIPTION
 Clears whole texture at once for shadowAtlas Avoid samsung bug on scissor+glClear
 Fixes shadowAtlas recent light and compiler refactors broke it.