### PR TITLE
[#D3D-3238] Fixes morph animation linking

### DIFF
--- a/sources/osgAnimation/BasicAnimationManager.js
+++ b/sources/osgAnimation/BasicAnimationManager.js
@@ -443,7 +443,7 @@ BasicAnimationManager.prototype = MACROUTILS.objectInherit( BaseObject.prototype
             } else if ( animationCallback instanceof UpdateMorph ) {
                 for ( var t = 0, numTarget = animationCallback.getNumTarget(); t < numTarget; t++ ) {
                     name = animationCallback.getTargetName( t );
-                    uniqueTargetName = name + '.' + t;
+                    uniqueTargetName = name + '.' + animationCallback.getName();
                     target = animationCallback.getTarget( t );
 
                     registerTarget( uniqueTargetName, target, name );


### PR DESCRIPTION
Animation linking is made using a uniqueTargetName: targetName + '.' + channelName
For morph, it was built with targetName + '.' + morphTargetIndex, that worked until now
since channelName == targetIndex. For unicity reasons, channelName can be different
so the linking doesn't work.
Remplacing the index by the actual channelName (that corresponds to the name of the updateMorph element here).