### PR TITLE
Fixes typo in intersection visitor

### DIFF
--- a/sources/osgUtil/LineSegmentIntersector.js
+++ b/sources/osgUtil/LineSegmentIntersector.js
@@ -112,13 +112,10 @@ LineSegmentIntersector.prototype = {
             var kdtree = node.getShape();
 
             if (kdtree) {
-                return kdtree.intersectLineSegment(
-                    lsf,
-                    kdtree.getNodes()[0],
-                    this._iStart,
-                    this._iEnd
-                );
+                kdtree.intersectLineSegment(lsf, kdtree.getNodes()[0], this._iStart, this._iEnd);
+                return;
             }
+
             // handle rig transformed vertices
             if (node.computeTransformedVertices) {
                 var vList = node.getVertexAttributeList();

--- a/sources/osgUtil/SphereIntersector.js
+++ b/sources/osgUtil/SphereIntersector.js
@@ -76,8 +76,10 @@ SphereIntersector.prototype = {
 
             var kdtree = node.getShape();
             if (kdtree) {
-                return kdtree.intersect(sif, kdtree.getNodes()[0]);
+                kdtree.intersect(sif, kdtree.getNodes()[0]);
+                return;
             }
+
             if (node.computeTransformedVertices) {
                 var vList = node.getVertexAttributeList();
                 var originVerts = vList.Vertex.getElements();
@@ -90,7 +92,6 @@ SphereIntersector.prototype = {
             } else {
                 sif.apply(node);
             }
-            return this._intersections > 0;
         };
     })(),
 


### PR DESCRIPTION
(the typo `this._intersections > 0` vs `this._intersections.length > 0` has a very big perf impact for some reasons)