### PR TITLE
Adds earlyout on datapager sort

### DIFF
--- a/sources/osgDB/DatabasePager.js
+++ b/sources/osgDB/DatabasePager.js
@@ -208,7 +208,7 @@ MACROUTILS.createPrototypeObject(
         },
 
         addLoadedDataToSceneGraph: function(frameStamp, availableTime) {
-            if (availableTime <= 0.0) return 0.0;
+            if (!this._pendingNodes.length || availableTime <= 0.0) return 0.0;
 
             // Prune the list of database requests.
             var elapsedTime = 0.0;


### PR DESCRIPTION
Gain few cpu time ms on old mobile and lowend desktop cpu as it's called each frame.
With that commit, the function disappear from the profiler,  as it seems the native "this._pendingNodes.sort" call is not that optimized, And as it's the most common case, I think it's worth it for such a small change.