### PR TITLE
Avoids sparse array in StateSet and State

### DIFF
--- a/examples/multi-viewport-rtt/main.js
+++ b/examples/multi-viewport-rtt/main.js
@@ -20,10 +20,11 @@
             var size = texture.getWidth() / num;
             var offset = index * size;
             camera.setViewport(new osg.Viewport(offset, 0, size, texture.getHeight()));
+            camera.setScissor(new osg.Scissor(offset, 0, size, texture.getHeight()));
             camera.setClearColor(clearColor);
-            camera
-                .getOrCreateStateSet()
-                .setAttributeAndModes(new osg.Scissor(offset, 0, size, texture.getHeight()));
+
+            var stateSet = camera.getOrCreateStateSet();
+            stateSet.setAttributeAndModes(new osg.BlendFunc(osg.BlendFunc.DISABLE));
 
             camera.setRenderOrder(osg.Camera.PRE_RENDER, 0);
             camera.attachTexture(osg.FrameBufferObject.COLOR_ATTACHMENT0, texture);
@@ -103,10 +104,10 @@
             ];
 
             var clearColors = [
-                osg.vec4.fromValues(1, 0, 0, 0),
-                osg.vec4.fromValues(0, 1, 0, 0),
-                osg.vec4.fromValues(0, 0, 1, 0),
-                osg.vec4.fromValues(1, 0, 1, 0)
+                osg.vec4.fromValues(1, 0, 0, 1),
+                osg.vec4.fromValues(0, 1, 0, 1),
+                osg.vec4.fromValues(0, 0, 1, 1),
+                osg.vec4.fromValues(1, 0, 1, 1)
             ];
 
             for (var i = 0; i < num; i++) {

--- a/sources/osg/Camera.js
+++ b/sources/osg/Camera.js
@@ -18,6 +18,7 @@ var Camera = function() {
 
     this.viewport = undefined;
     this._graphicContext = undefined;
+    this._scissor = undefined;
     this.setClearColor(vec4.fromValues(0, 0, 0, 1.0));
     this.setClearDepth(1.0);
 
@@ -125,6 +126,14 @@ MACROUTILS.createPrototypeNode(
             },
             getViewport: function() {
                 return this.viewport;
+            },
+
+            setScissor: function(scissor) {
+                this._scissor = scissor;
+                this.getOrCreateStateSet().setAttributeAndModes(this._scissor);
+            },
+            getScissor: function() {
+                return this._scissor;
             },
 
             setViewMatrix: function(matrix) {

--- a/sources/osg/CullVisitor.js
+++ b/sources/osg/CullVisitor.js
@@ -519,8 +519,6 @@ var cameraApply = function(camera) {
     if (camera.getRenderOrder() === Camera.NESTED_RENDER) {
         this.handleCullCallbacksAndTraverse(camera);
     } else {
-        // not tested
-
         var renderBin = this.getCurrentRenderBin();
         var previousStage = renderBin.getStage();
 
@@ -532,13 +530,10 @@ var cameraApply = function(camera) {
         rtts.setClearColor(camera.getClearColor());
         rtts.setClearMask(camera.getClearMask());
 
-        var vp;
-        if (camera.getViewport() === undefined) {
-            vp = previousStage.getViewport();
-        } else {
-            vp = camera.getViewport();
-        }
-        rtts.setViewport(vp);
+        var viewport = camera.getViewport() ? camera.getViewport() : previousStage.getViewport();
+        var scissor = camera.getScissor() ? camera.getScissor() : previousStage.getScissor();
+        rtts.setViewport(viewport);
+        rtts.setScissor(scissor);
 
         // skip positional state for now
         // ...

--- a/sources/osg/RenderBin.js
+++ b/sources/osg/RenderBin.js
@@ -8,7 +8,7 @@ var PooledArray = require('osg/PooledArray');
 var PooledMap = require('osg/PooledMap');
 
 var createPositionAttribute = function() {
-    return new Array(2);
+    return [null, null];
 };
 
 /**

--- a/sources/osg/RenderStage.js
+++ b/sources/osg/RenderStage.js
@@ -24,6 +24,7 @@ var RenderStage = function() {
     this._clearMask = undefined;
     this._camera = undefined;
     this._viewport = undefined;
+    this._scissor = undefined;
     this._preRenderList = [];
     this._postRenderList = [];
     // calling prototype to make sure
@@ -52,6 +53,7 @@ MACROUTILS.createPrototypeObject(
             /*jshint bitwise: true */
             this._camera = undefined;
             this._viewport = undefined;
+            this._scissor = undefined;
             this._renderStage = this;
             RenderStage.prototype._initInternal.call(this);
             return this;
@@ -98,6 +100,14 @@ MACROUTILS.createPrototypeObject(
 
         getViewport: function() {
             return this._viewport;
+        },
+
+        setScissor: function(scissor) {
+            this._scissor = scissor;
+        },
+
+        getScissor: function() {
+            return this._scissor;
         },
 
         setCamera: function(camera) {
@@ -272,7 +282,10 @@ MACROUTILS.createPrototypeObject(
             }
             state.applyAttribute(this._viewport);
 
-            /*jshint bitwise: false */
+            if (this._scissor) {
+                state.applyAttribute(this._scissor);
+            }
+
             if (this._clearMask !== 0x0) {
                 if (this._clearMask & gl.COLOR_BUFFER_BIT) {
                     gl.clearColor(
@@ -286,7 +299,6 @@ MACROUTILS.createPrototypeObject(
                     gl.depthMask(true);
                     gl.clearDepth(this._clearDepth);
                 }
-                /*jshint bitwise: true */
                 gl.clear(this._clearMask);
             }
 

--- a/sources/osg/Utils.js
+++ b/sources/osg/Utils.js
@@ -127,6 +127,15 @@ Utils.objectMix = function(obj, properties, test) {
 Utils.objectType = {};
 Utils.objectType.type = 0;
 
+Utils.makeDenseArray = function(index, array, createDefaultType) {
+    var length = array.length;
+    if (index >= length) {
+        for (var i = length; i <= index; i++) {
+            array.push(createDefaultType ? createDefaultType() : null);
+        }
+    }
+};
+
 Utils.objectLibraryClass = function(object, libName, className) {
     object.className = function() {
         return className;
@@ -209,6 +218,7 @@ Utils.createPrototypeNode = function(Constructor, prototype, libraryName, classN
 
     Utils.setNodeTypeID(Constructor);
     var nodeTypeId = Constructor.nodeTypeID;
+    Utils.makeDenseArray(nodeTypeId, cullVisitorHelper.applyFunctionArray);
     cullVisitorHelper.registerApplyFunction(
         nodeTypeId,
         cullVisitorHelper.getApplyFunction(parentNodeTypeID)

--- a/sources/osgShader/ShaderGenerator.js
+++ b/sources/osgShader/ShaderGenerator.js
@@ -55,7 +55,7 @@ ShaderGenerator.prototype = {
 
         for (var j = 0, k = cacheType.length; j < k; j++) {
             var type = cacheType[j];
-            var attributeStack = _attributeArray[type];
+            var attributeStack = type < _attributeArray.length ? _attributeArray[type] : undefined;
             if (!attributeStack) continue;
 
             var attribute = attributeStack._lastApplied;
@@ -76,7 +76,8 @@ ShaderGenerator.prototype = {
         var cacheType = this._ShaderCompiler._validAttributeTypeMemberCache;
         for (var i = 0, l = cacheType.length; i < l; i++) {
             var type = cacheType[i];
-            var attributeStack = state._attributeArray[type];
+            var attributeStack =
+                type < state._attributeArray.length ? state._attributeArray[type] : undefined;
             if (attributeStack) {
                 var attribute = attributeStack._lastApplied;
                 if (!attribute || this.filterAttributeTypes(attribute)) continue;
@@ -98,9 +99,10 @@ ShaderGenerator.prototype = {
             var textureUnit = textureUnitList[j];
             if (!textureUnit) continue;
 
+            var textureUnitLength = textureUnit.length;
             for (var i = 0; i < cacheType.length; i++) {
                 var type = cacheType[i];
-                var attributeStack = textureUnit[type];
+                var attributeStack = type < textureUnitLength ? textureUnit[type] : undefined;
                 if (attributeStack) {
                     var attribute = attributeStack._lastApplied;
 
@@ -138,7 +140,8 @@ ShaderGenerator.prototype = {
             for (var j = 0, m = cacheType.length; j < m; j++) {
                 var type = cacheType[j];
 
-                var attributeStack = _attributeArrayForUnit[type];
+                var attributeStack =
+                    type < _attributeArrayForUnit.length ? _attributeArrayForUnit[type] : undefined;
                 if (!attributeStack) continue;
 
                 var attribute = attributeStack._lastApplied;

--- a/sources/osgViewer/Renderer.js
+++ b/sources/osgViewer/Renderer.js
@@ -158,12 +158,16 @@ MACROUTILS.createPrototypeObject(
                 }
             }
 
-            this._cullVisitor.pushViewport(camera.getViewport());
+            var viewport = camera.getViewport();
+            var scissor = camera.getScissor();
+
+            this._cullVisitor.pushViewport(viewport);
 
             this._renderStage.setClearDepth(camera.getClearDepth());
             this._renderStage.setClearColor(camera.getClearColor());
             this._renderStage.setClearMask(camera.getClearMask());
-            this._renderStage.setViewport(camera.getViewport());
+            this._renderStage.setViewport(viewport);
+            this._renderStage.setScissor(scissor);
 
             // pass de dbpager to the cullvisitor, so plod's can do the requests
             this._cullVisitor.setDatabaseRequestHandler(this._camera.getView().getDatabasePager());

--- a/sources/osgViewer/View.js
+++ b/sources/osgViewer/View.js
@@ -8,6 +8,7 @@ var mat4 = require('osg/glMatrix').mat4;
 var Texture = require('osg/Texture');
 var Program = require('osg/Program');
 var Shader = require('osg/Shader');
+var Scissor = require('osg/Scissor');
 var vec3 = require('osg/glMatrix').vec3;
 var Viewport = require('osg/Viewport');
 var WebGLCaps = require('osg/WebGLCaps');
@@ -155,6 +156,7 @@ View.prototype = {
         var ratio = width / height;
 
         this._camera.setViewport(new Viewport(0, 0, width, height));
+        this._camera.setScissor(new Scissor());
 
         this._camera.setGraphicContext(this.getGraphicContext());
         mat4.lookAt(


### PR DESCRIPTION
It does not seems to have a big effect on performance sample even if it seems a bit faster on chrome and similar in firefox, but on safari it seems more interesting

this the timing of 'render' in stats
chrome:
3.6/3.7 (master)
3.3/3.45 (avoid-sparse-array)

firefox:
4.7/4.9 (master)
4.5/4.8 (avoid-sparse-array)

safari:
6.7/6.9 (master)
5.5/5.8 (avoid-sparse-array)

Also adds a better handling of Scissor