### PR TITLE
Fixes VAO with non VAO geometry

### DIFF
--- a/sources/osg/Geometry.js
+++ b/sources/osg/Geometry.js
@@ -325,15 +325,13 @@ utils.createPrototypeNode(
             state.drawGeometry(this);
             var cachedDraw = this._cacheDrawCall[prgID];
 
-            if (this._useVAO) {
-                if (!this._vao[prgID]) {
-                    state.setVertexArrayObject(null);
-                } else {
-                    if (this._vao[prgID].isDirty()) {
-                        // need vertex array recreation
-                        // ie: lost context
-                        cachedDraw = undefined;
-                    }
+            if (!this._vao[prgID]) {
+                state.setVertexArrayObject(null);
+            } else {
+                if (this._vao[prgID].isDirty()) {
+                    // need vertex array recreation
+                    // ie: lost context
+                    cachedDraw = undefined;
                 }
             }
 


### PR DESCRIPTION
When using Morph geometry with BufferProxy the geometry does not use vao
so when we had something like:
Geometry VAO
Geomtry Non-VAO

The second geometry was changing the VAO of the first geometry. The fix
disable VAO when drawing the second geometry.