### PR TITLE
Cleans nodeGizmo attachToNode behavior

### DIFF
--- a/sources/osgUtil/NodeGizmo.js
+++ b/sources/osgUtil/NodeGizmo.js
@@ -831,6 +831,8 @@ utils.createPrototypeNode(
             getCanvasCoord(this._downCanvasCoord, e);
             if (!this._hoverNode || !this._attachedNode) return;
 
+            e.preventDefault();
+
             this._enableMouseBack = this._eventMouse.getEnable();
             this._eventMouse.setEnable(false);
 


### PR DESCRIPTION
Removing the `attachToMatrixTransform` and `attachToGeometry` functions and replacing them with `attachToNode`.

(ideally `attachToNodePath` should be prefered)