### PR TITLE
Adds a function to reset the programs variables in GizmoGeometry

### DIFF
--- a/sources/osgUtil/gizmoGeometry.js
+++ b/sources/osgUtil/gizmoGeometry.js
@@ -124,6 +124,12 @@ var getOrCreateShaderQuadCircle = function() {
     return programQC;
 };
 
+var resetPrograms = function () {
+    program = undefined;
+    program2D = undefined;
+    programQC = undefined;
+};
+
 var createDebugLineGeometry = function() {
     var g = new Geometry();
     g.getAttributes().Vertex = new BufferArray(BufferArray.ARRAY_BUFFER, new Float32Array(4), 2);
@@ -349,5 +355,6 @@ GizmoGeometry.createTorusGeometry = createTorusGeometry;
 GizmoGeometry.createDebugLineGeometry = createDebugLineGeometry;
 GizmoGeometry.createPlaneGeometry = createPlaneGeometry;
 GizmoGeometry.createQuadCircleGeometry = createQuadCircleGeometry;
+GizmoGeometry.resetPrograms = resetPrograms;
 
 export default GizmoGeometry;


### PR DESCRIPTION
Calling this function avoids problems when creating a new gizmo in a new glContext. The problem is that when a gizmo is created the programs in GizmoGeometry (which are global) are instantiated. After that if a new gizmo is created in a new glContext, the Gizmo Geometry tries to use the programs variables because they aren't undefined but it doesn't work since these programs are associated to the first glContext,