### PR TITLE
Improves stats

### DIFF
--- a/sources/osg/Options.js
+++ b/sources/osg/Options.js
@@ -6,10 +6,13 @@ var OptionsDefault = {
     //'overrideDevicePixelRatio': 1, // if specified override the device pixel ratio
     fullscreen: true,
     enableFrustumCulling: false,
-    stats: false, // display canvas with stats for the viewer
     scrollwheel: true,
     webgl2: false,
-    powerPreference: 'high-performance'
+    powerPreference: 'high-performance',
+    stats: false // display stats, check in osgStats/Stats for all url options
+    // statsFilter=cull;myGroup;webgl filters groups to display
+    // statsFontSize=12 change the size of the fonts default 12
+    // statsShowGraph=1 display graph
 };
 
 var Options = function() {

--- a/sources/osgGA/CADManipulatorHammerController.js
+++ b/sources/osgGA/CADManipulatorHammerController.js
@@ -1,228 +1,247 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+
 var CADManipulatorHammerController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this._timer = false;
     this.init();
 };
 
-CADManipulatorHammerController.prototype = {
-    init: function() {
-        this._panFactorX = 1.0;
-        this._panFactorY = -this._panFactorX;
+utils.createPrototypeObject(
+    CADManipulatorHammerController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._panFactorX = 1.0;
+            this._panFactorY = -this._panFactorX;
 
-        this._rotateFactorX = 0.6;
-        this._rotateFactorY = -this._rotateFactorX;
-        this._zoomFactor = 5.0;
+            this._rotateFactorX = 0.6;
+            this._rotateFactorY = -this._rotateFactorX;
+            this._zoomFactor = 5.0;
 
-        this._lastScale = 0;
-        this._nbPointerLast = 0; // to check if we the number of pointers has changed
+            this._lastScale = 0;
+            this._nbPointerLast = 0; // to check if we the number of pointers has changed
 
-        this._lastPos = undefined; // to set the pivot for rotation
+            this._lastPos = undefined; // to set the pivot for rotation
+            this._dragStarted = false;
+            this._transformStarted = false;
+            this._isValid = false;
+        },
 
-        this._isValid = false;
-    },
-
-    setValid: function(valid) {
-        this._isValid = valid;
-    },
-
-    setEventProxy: function(hammer) {
-        if (!hammer || hammer === this._eventProxy) {
-            return;
-        }
-
-        this._eventProxy = hammer;
-
-        // Set a minimal thresold on pinch event, to be detected after pan
-        hammer.get('pinch').set({
-            threshold: 0.1
-        });
-        // Let the pan be detected with two fingers.
-        hammer.get('pan').set({
-            threshold: 0,
-            pointers: 0
-        });
-        hammer.get('pinch').recognizeWith(hammer.get('pan'));
-
-        hammer.get('tap').set({
-            taps: 2,
-            posThreshold: 300
-        });
-
-        this._cbPanStart = this.panStart.bind(this);
-        this._cbPanMove = this.panMove.bind(this);
-        this._cbPanEnd = this.panEnd.bind(this);
-        this._cbPinchStart = this.pinchStart.bind(this);
-        this._cbPinchEnd = this.pinchEnd.bind(this);
-        this._cbPinchInOut = this.pinchInOut.bind(this);
-        this._cbDoubleTap = this.doubleTap.bind(this);
-
-        hammer.on('panstart ', this._cbPanStart);
-        hammer.on('panmove', this._cbPanMove);
-        hammer.on('panend', this._cbPanEnd);
-        hammer.on('pinchstart', this._cbPinchStart);
-        hammer.on('pinchend', this._cbPinchEnd);
-        hammer.on('pinchin pinchout', this._cbPinchInOut);
-        hammer.on('tap', this._cbDoubleTap);
-    },
-
-    _computeTouches: function(event) {
-        if (event.pointers !== undefined) return event.pointers.length;
-        return 1; // mouse
-    },
-
-    panStart: function(event) {
-        if (!this._isValid) return;
-
-        var manipulator = this._manipulator;
-        if (!manipulator || this._transformStarted || event.pointerType === 'mouse') {
-            return;
-        }
-
-        this._dragStarted = true;
-        this._nbPointerLast = this._computeTouches(event);
-
-        var pos;
-        if (this._nbPointerLast === 2) {
-            pos = manipulator.getPositionRelativeToCanvas(event.center.x, event.center.y);
-            this._lastPos = pos;
-        } else {
-            if (this._lastPos === undefined) {
-                pos = manipulator.getCanvasCenter();
-            } else {
-                pos = this._lastPos;
+        // called to enable/disable controller
+        setEnable: function(bool) {
+            if (!bool) {
+                // reset mode if we disable it
+                this._dragStarted = false;
+                this._lastPos = undefined;
+                this._transformStarted = false;
+                this._nbPointerLast = 0;
             }
+            Controller.prototype.setEnable.call(this, bool);
+        },
+
+        setValid: function(valid) {
+            this._isValid = valid;
+        },
+
+        setEventProxy: function(hammer) {
+            if (!hammer || hammer === this._eventProxy) {
+                return;
+            }
+
+            this._eventProxy = hammer;
+
+            // Set a minimal thresold on pinch event, to be detected after pan
+            hammer.get('pinch').set({
+                threshold: 0.1
+            });
+            // Let the pan be detected with two fingers.
+            hammer.get('pan').set({
+                threshold: 0,
+                pointers: 0
+            });
+            hammer.get('pinch').recognizeWith(hammer.get('pan'));
+
+            hammer.get('tap').set({
+                taps: 2,
+                posThreshold: 300
+            });
+
+            this._cbPanStart = this.panStart.bind(this);
+            this._cbPanMove = this.panMove.bind(this);
+            this._cbPanEnd = this.panEnd.bind(this);
+            this._cbPinchStart = this.pinchStart.bind(this);
+            this._cbPinchEnd = this.pinchEnd.bind(this);
+            this._cbPinchInOut = this.pinchInOut.bind(this);
+            this._cbDoubleTap = this.doubleTap.bind(this);
+
+            hammer.on('panstart ', this._cbPanStart);
+            hammer.on('panmove', this._cbPanMove);
+            hammer.on('panend', this._cbPanEnd);
+            hammer.on('pinchstart', this._cbPinchStart);
+            hammer.on('pinchend', this._cbPinchEnd);
+            hammer.on('pinchin pinchout', this._cbPinchInOut);
+            hammer.on('tap', this._cbDoubleTap);
+        },
+
+        _computeTouches: function(event) {
+            if (event.pointers !== undefined) return event.pointers.length;
+            return 1; // mouse
+        },
+
+        panStart: function(event) {
+            if (!this._isValid) return;
+
+            var manipulator = this._manipulator;
+            if (!manipulator || this._transformStarted || event.pointerType === 'mouse') {
+                return;
+            }
+
+            this._dragStarted = true;
+            this._nbPointerLast = this._computeTouches(event);
+
+            var pos;
+            if (this._nbPointerLast === 2) {
+                pos = manipulator.getPositionRelativeToCanvas(event.center.x, event.center.y);
+                this._lastPos = pos;
+            } else {
+                if (this._lastPos === undefined) {
+                    pos = manipulator.getCanvasCenter();
+                } else {
+                    pos = this._lastPos;
+                }
+            }
+
+            manipulator.computeIntersections(pos);
+
+            if (this._nbPointerLast === 2) {
+                var panInterpolator = manipulator.getPanInterpolator();
+                manipulator.getPanInterpolator().reset();
+                var xPan = event.center.x * this._panFactorX;
+                var yPan = event.center.y * this._panFactorY;
+                panInterpolator.set(xPan, yPan);
+            } else {
+                manipulator.getRotateInterpolator().reset();
+            }
+        },
+
+        panMove: function(event) {
+            if (!this._isValid) return;
+
+            var manipulator = this._manipulator;
+            if (!manipulator || !this._dragStarted || event.pointerType === 'mouse') {
+                return;
+            }
+
+            var nbPointers = this._computeTouches(event);
+
+            // prevent sudden big changes in the event.center variables
+            if (this._nbPointerLast !== nbPointers) {
+                if (nbPointers === 2) manipulator.getPanInterpolator().reset();
+                else manipulator.getRotateInterpolator().reset();
+                this._nbPointerLast = nbPointers;
+            }
+
+            if (nbPointers === 2) {
+                var panInterpolator = manipulator.getPanInterpolator();
+                var xPan = event.center.x * this._panFactorX;
+                var yPan = event.center.y * this._panFactorY;
+                panInterpolator.setTarget(xPan, yPan);
+            } else {
+                var rotateInterpolator = manipulator.getRotateInterpolator();
+                var xRot = event.center.x * this._rotateFactorX;
+                var yRot = event.center.y * this._rotateFactorY;
+                rotateInterpolator.setTarget(xRot, yRot);
+            }
+        },
+
+        panEnd: function(event) {
+            if (!this._isValid) return;
+
+            var manipulator = this._manipulator;
+            if (!manipulator || !this._dragStarted || event.pointerType === 'mouse') {
+                return;
+            }
+
+            this._dragStarted = false;
+        },
+
+        pinchStart: function(event) {
+            if (!this._isValid) return;
+
+            var manipulator = this._manipulator;
+            if (!manipulator || event.pointerType === 'mouse') {
+                return;
+            }
+
+            this._transformStarted = true;
+
+            this._lastScale = event.scale;
+            manipulator.getZoomInterpolator().reset();
+            manipulator.getZoomInterpolator().set(this._lastScale);
+            event.preventDefault();
+        },
+
+        pinchEnd: function(event) {
+            if (!this._isValid) return;
+
+            if (event.pointerType === 'mouse') {
+                return;
+            }
+
+            this._transformStarted = false;
+        },
+
+        pinchInOut: function(event) {
+            if (!this._isValid) return;
+
+            var manipulator = this._manipulator;
+            if (!manipulator || !this._transformStarted || event.pointerType === 'mouse') {
+                return;
+            }
+
+            // make the dezoom faster
+            var isZoomIn = event.scale > this._lastScale;
+            var zoomFactor = isZoomIn ? this._zoomFactor : this._zoomFactor * 4.0;
+            var scale = (event.scale - this._lastScale) * zoomFactor;
+            this._lastScale = event.scale;
+
+            var zoomInterpolator = manipulator.getZoomInterpolator();
+            zoomInterpolator.setTarget(zoomInterpolator.getTarget()[0] - scale);
+        },
+
+        doubleTap: function(event) {
+            if (!this._isValid) return;
+
+            var manipulator = this._manipulator;
+            if (!manipulator || event.pointerType === 'mouse') {
+                return;
+            }
+
+            var pos = manipulator.getPositionRelativeToCanvas(event.center.x, event.center.y);
+            this._lastPos = pos;
+
+            manipulator.getZoomInterpolator().set(0.0);
+            var zoomInterpolator = manipulator.getZoomInterpolator();
+            // Default interval 10
+            zoomInterpolator.setTarget(zoomInterpolator.getTarget()[0] - 10);
+        },
+
+        removeEventProxy: function(proxy) {
+            if (!proxy || !this._eventProxy) return;
+
+            proxy.off('panstart ', this._cbPanStart);
+            proxy.off('panmove', this._cbPanMove);
+            proxy.off('panend', this._cbPanEnd);
+            proxy.off('pinchstart', this._cbPinchStart);
+            proxy.off('pinchend', this._cbPinchEnd);
+            proxy.off('pinchin pinchout', this._cbPinchInOut);
+            proxy.off('tap', this._cbDoubleTap);
+        },
+
+        setManipulator: function(manipulator) {
+            this._manipulator = manipulator;
         }
-
-        manipulator.computeIntersections(pos);
-
-        if (this._nbPointerLast === 2) {
-            var panInterpolator = manipulator.getPanInterpolator();
-            manipulator.getPanInterpolator().reset();
-            var xPan = event.center.x * this._panFactorX;
-            var yPan = event.center.y * this._panFactorY;
-            panInterpolator.set(xPan, yPan);
-        } else {
-            manipulator.getRotateInterpolator().reset();
-        }
-    },
-
-    panMove: function(event) {
-        if (!this._isValid) return;
-
-        var manipulator = this._manipulator;
-        if (!manipulator || !this._dragStarted || event.pointerType === 'mouse') {
-            return;
-        }
-
-        var nbPointers = this._computeTouches(event);
-
-        // prevent sudden big changes in the event.center variables
-        if (this._nbPointerLast !== nbPointers) {
-            if (nbPointers === 2) manipulator.getPanInterpolator().reset();
-            else manipulator.getRotateInterpolator().reset();
-            this._nbPointerLast = nbPointers;
-        }
-
-        if (nbPointers === 2) {
-            var panInterpolator = manipulator.getPanInterpolator();
-            var xPan = event.center.x * this._panFactorX;
-            var yPan = event.center.y * this._panFactorY;
-            panInterpolator.setTarget(xPan, yPan);
-        } else {
-            var rotateInterpolator = manipulator.getRotateInterpolator();
-            var xRot = event.center.x * this._rotateFactorX;
-            var yRot = event.center.y * this._rotateFactorY;
-            rotateInterpolator.setTarget(xRot, yRot);
-        }
-    },
-
-    panEnd: function(event) {
-        if (!this._isValid) return;
-
-        var manipulator = this._manipulator;
-        if (!manipulator || !this._dragStarted || event.pointerType === 'mouse') {
-            return;
-        }
-
-        this._dragStarted = false;
-    },
-
-    pinchStart: function(event) {
-        if (!this._isValid) return;
-
-        var manipulator = this._manipulator;
-        if (!manipulator || event.pointerType === 'mouse') {
-            return;
-        }
-
-        this._transformStarted = true;
-
-        this._lastScale = event.scale;
-        manipulator.getZoomInterpolator().reset();
-        manipulator.getZoomInterpolator().set(this._lastScale);
-        event.preventDefault();
-    },
-
-    pinchEnd: function(event) {
-        if (!this._isValid) return;
-
-        if (event.pointerType === 'mouse') {
-            return;
-        }
-
-        this._transformStarted = false;
-    },
-
-    pinchInOut: function(event) {
-        if (!this._isValid) return;
-
-        var manipulator = this._manipulator;
-        if (!manipulator || !this._transformStarted || event.pointerType === 'mouse') {
-            return;
-        }
-
-        // make the dezoom faster
-        var isZoomIn = event.scale > this._lastScale;
-        var zoomFactor = isZoomIn ? this._zoomFactor : this._zoomFactor * 4.0;
-        var scale = (event.scale - this._lastScale) * zoomFactor;
-        this._lastScale = event.scale;
-
-        var zoomInterpolator = manipulator.getZoomInterpolator();
-        zoomInterpolator.setTarget(zoomInterpolator.getTarget()[0] - scale);
-    },
-
-    doubleTap: function(event) {
-        if (!this._isValid) return;
-
-        var manipulator = this._manipulator;
-        if (!manipulator || event.pointerType === 'mouse') {
-            return;
-        }
-
-        var pos = manipulator.getPositionRelativeToCanvas(event.center.x, event.center.y);
-        this._lastPos = pos;
-
-        manipulator.getZoomInterpolator().set(0.0);
-        var zoomInterpolator = manipulator.getZoomInterpolator();
-        // Default interval 10
-        zoomInterpolator.setTarget(zoomInterpolator.getTarget()[0] - 10);
-    },
-
-    removeEventProxy: function(proxy) {
-        if (!proxy || !this._eventProxy) return;
-
-        proxy.off('panstart ', this._cbPanStart);
-        proxy.off('panmove', this._cbPanMove);
-        proxy.off('panend', this._cbPanEnd);
-        proxy.off('pinchstart', this._cbPinchStart);
-        proxy.off('pinchend', this._cbPinchEnd);
-        proxy.off('pinchin pinchout', this._cbPinchInOut);
-        proxy.off('tap', this._cbDoubleTap);
-    },
-
-    setManipulator: function(manipulator) {
-        this._manipulator = manipulator;
-    }
-};
+    })
+);
 
 export default CADManipulatorHammerController;

--- a/sources/osgGA/CADManipulatorStandardMouseKeyboardController.js
+++ b/sources/osgGA/CADManipulatorStandardMouseKeyboardController.js
@@ -1,171 +1,188 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
 import OrbitManipulator from 'osgGA/OrbitManipulator';
 
 var CADManipulatorStandardMouseKeyboardController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this._timer = false;
     this.init();
 };
 
-CADManipulatorStandardMouseKeyboardController.prototype = {
-    init: function() {
-        this.releaseButton();
-        this._rotateKey = 65; // a
-        this._zoomKey = 83; // s
-        this._panKey = 68; // d
-        this._mode = undefined;
-    },
-    getMode: function() {
-        return this._mode;
-    },
-    setMode: function(mode) {
-        this._mode = mode;
-    },
-    setEventProxy: function(proxy) {
-        this._eventProxy = proxy;
-    },
-    setManipulator: function(manipulator) {
-        this._manipulator = manipulator;
-    },
+utils.createPrototypeObject(
+    CADManipulatorStandardMouseKeyboardController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._rotateKey = 65; // a
+            this._zoomKey = 83; // s
+            this._panKey = 68; // d
 
-    mousemove: function(ev) {
-        if (this._buttonup === true) {
-            return;
-        }
+            this._mode = undefined;
+            this._buttonup = true;
+        },
+        // called to enable/disable controller
+        setEnable: function(bool) {
+            if (!bool) {
+                // reset mode if we disable it
+                this._mode = undefined;
+            }
+            Controller.prototype.setEnable.call(this, bool);
+        },
+        getMode: function() {
+            return this._mode;
+        },
+        setMode: function(mode) {
+            this._mode = mode;
+        },
+        setEventProxy: function(proxy) {
+            this._eventProxy = proxy;
+        },
+        setManipulator: function(manipulator) {
+            this._manipulator = manipulator;
+        },
 
-        var manipulator = this._manipulator;
-        var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
+        mousemove: function(ev) {
+            if (this._buttonup === true) {
+                return;
+            }
 
-        if (isNaN(pos[0]) === false && isNaN(pos[1]) === false) {
-            var mode = this.getMode();
-            if (mode === OrbitManipulator.Rotate) {
-                manipulator.getRotateInterpolator().setTarget(pos[0], pos[1]);
-            } else if (mode === OrbitManipulator.Pan) {
-                manipulator.getPanInterpolator().setTarget(pos[0], pos[1]);
-            } else if (mode === OrbitManipulator.Zoom) {
-                var zoom = manipulator.getZoomInterpolator();
-                manipulator.computeIntersections(pos);
+            var manipulator = this._manipulator;
+            var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
 
-                if (zoom.isReset()) {
+            if (isNaN(pos[0]) === false && isNaN(pos[1]) === false) {
+                var mode = this.getMode();
+                if (mode === OrbitManipulator.Rotate) {
+                    manipulator.getRotateInterpolator().setTarget(pos[0], pos[1]);
+                } else if (mode === OrbitManipulator.Pan) {
+                    manipulator.getPanInterpolator().setTarget(pos[0], pos[1]);
+                } else if (mode === OrbitManipulator.Zoom) {
+                    var zoom = manipulator.getZoomInterpolator();
+                    manipulator.computeIntersections(pos);
+
+                    if (zoom.isReset()) {
+                        zoom.setStart(pos[1]);
+                        zoom.set(0.0);
+                    }
+                    var dy = pos[1] - zoom.getStart();
                     zoom.setStart(pos[1]);
-                    zoom.set(0.0);
+                    var v = zoom.getTarget()[0];
+                    zoom.setTarget(v - dy / 20.0);
                 }
-                var dy = pos[1] - zoom.getStart();
-                zoom.setStart(pos[1]);
-                var v = zoom.getTarget()[0];
-                zoom.setTarget(v - dy / 20.0);
             }
-        }
 
-        ev.preventDefault();
-    },
-    mousedown: function(ev) {
-        var manipulator = this._manipulator;
-        var mode = this.getMode();
-        if (mode === undefined) {
-            if (ev.button === 0) {
-                if (ev.shiftKey) {
-                    this.setMode(OrbitManipulator.Pan);
-                } else if (ev.ctrlKey) {
-                    this.setMode(OrbitManipulator.Zoom);
+            ev.preventDefault();
+        },
+        mousedown: function(ev) {
+            var manipulator = this._manipulator;
+            var mode = this.getMode();
+            if (mode === undefined) {
+                if (ev.button === 0) {
+                    if (ev.shiftKey) {
+                        this.setMode(OrbitManipulator.Pan);
+                    } else if (ev.ctrlKey) {
+                        this.setMode(OrbitManipulator.Zoom);
+                    } else {
+                        this.setMode(OrbitManipulator.Rotate);
+                    }
                 } else {
-                    this.setMode(OrbitManipulator.Rotate);
+                    this.setMode(OrbitManipulator.Pan);
                 }
-            } else {
-                this.setMode(OrbitManipulator.Pan);
             }
-        }
 
-        this.pushButton();
+            this.pushButton();
 
-        //var pos = this.getPositionRelativeToCanvas( ev );
-        var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
-        manipulator.computeIntersections(pos);
-
-        mode = this.getMode();
-        if (mode === OrbitManipulator.Rotate) {
-            manipulator.getRotateInterpolator().reset();
-            manipulator.getRotateInterpolator().set(pos[0], pos[1]);
-        } else if (mode === OrbitManipulator.Pan) {
-            manipulator.getPanInterpolator().reset();
-            manipulator.getPanInterpolator().set(pos[0], pos[1]);
-        } else if (mode === OrbitManipulator.Zoom) {
-            manipulator.getZoomInterpolator().setStart(pos[1]);
-            manipulator.getZoomInterpolator().set(0.0);
-        }
-    },
-    mouseup: function(/*ev */) {
-        this.releaseButton();
-        this.setMode(undefined);
-    },
-    mousewheel: function(ev, intDelta /*, deltaX, deltaY */) {
-        var manipulator = this._manipulator;
-        var zoomTarget = manipulator.getZoomInterpolator().getTarget()[0] - intDelta;
-        manipulator.getZoomInterpolator().setTarget(zoomTarget);
-        var timer;
-        if (this._timer === false) {
-            this._timer = true;
-            var that = this;
-            clearTimeout(timer);
-            timer = setTimeout(function() {
-                that._timer = false;
-            }, 200);
             //var pos = this.getPositionRelativeToCanvas( ev );
             var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
             manipulator.computeIntersections(pos);
+
+            mode = this.getMode();
+            if (mode === OrbitManipulator.Rotate) {
+                manipulator.getRotateInterpolator().reset();
+                manipulator.getRotateInterpolator().set(pos[0], pos[1]);
+            } else if (mode === OrbitManipulator.Pan) {
+                manipulator.getPanInterpolator().reset();
+                manipulator.getPanInterpolator().set(pos[0], pos[1]);
+            } else if (mode === OrbitManipulator.Zoom) {
+                manipulator.getZoomInterpolator().setStart(pos[1]);
+                manipulator.getZoomInterpolator().set(0.0);
+            }
+        },
+        mouseup: function(/*ev */) {
+            this.releaseButton();
+            this.setMode(undefined);
+        },
+        mousewheel: function(ev, intDelta /*, deltaX, deltaY */) {
+            var manipulator = this._manipulator;
+            var zoomTarget = manipulator.getZoomInterpolator().getTarget()[0] - intDelta;
+            manipulator.getZoomInterpolator().setTarget(zoomTarget);
+            var timer;
+            if (this._timer === false) {
+                this._timer = true;
+                var that = this;
+                clearTimeout(timer);
+                timer = setTimeout(function() {
+                    that._timer = false;
+                }, 200);
+                //var pos = this.getPositionRelativeToCanvas( ev );
+                var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
+                manipulator.computeIntersections(pos);
+            }
+        },
+
+        dblclick: function(ev) {
+            var manipulator = this._manipulator;
+            ev.preventDefault();
+
+            manipulator.getZoomInterpolator().set(0.0);
+            var zoomTarget = manipulator.getZoomInterpolator().getTarget()[0] - 10; // Default interval 10
+            manipulator.getZoomInterpolator().setTarget(zoomTarget);
+            //var pos = this.getPositionRelativeToCanvas( ev );
+            var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
+            manipulator.computeIntersections(pos);
+        },
+
+        pushButton: function() {
+            this._buttonup = false;
+        },
+        releaseButton: function() {
+            this._buttonup = true;
+        },
+
+        keydown: function(ev) {
+            if (ev.keyCode === 32) {
+                this._manipulator.computeHomePosition();
+                ev.preventDefault();
+            } else if (ev.keyCode === this._panKey && this.getMode() !== OrbitManipulator.Pan) {
+                this.setMode(OrbitManipulator.Pan);
+                this._manipulator.getPanInterpolator().reset();
+                this.pushButton();
+                ev.preventDefault();
+            } else if (ev.keyCode === this._zoomKey && this.getMode() !== OrbitManipulator.Zoom) {
+                this.setMode(OrbitManipulator.Zoom);
+                this._manipulator.getZoomInterpolator().reset();
+                this.pushButton();
+                ev.preventDefault();
+            } else if (
+                ev.keyCode === this._rotateKey &&
+                this.getMode() !== OrbitManipulator.Rotate
+            ) {
+                this.setMode(OrbitManipulator.Rotate);
+                this._manipulator.getRotateInterpolator().reset();
+                this.pushButton();
+                ev.preventDefault();
+            }
+        },
+
+        keyup: function(ev) {
+            if (ev.keyCode === this._panKey) {
+                this.mouseup(ev);
+            } else if (ev.keyCode === this._rotateKey) {
+                this.mouseup(ev);
+            } else if (ev.keyCode === this._rotateKey) {
+                this.mouseup(ev);
+            }
+            this.setMode(undefined);
         }
-    },
-
-    dblclick: function(ev) {
-        var manipulator = this._manipulator;
-        ev.preventDefault();
-
-        manipulator.getZoomInterpolator().set(0.0);
-        var zoomTarget = manipulator.getZoomInterpolator().getTarget()[0] - 10; // Default interval 10
-        manipulator.getZoomInterpolator().setTarget(zoomTarget);
-        //var pos = this.getPositionRelativeToCanvas( ev );
-        var pos = manipulator.getPositionRelativeToCanvas(ev.clientX, ev.clientY);
-        manipulator.computeIntersections(pos);
-    },
-
-    pushButton: function() {
-        this._buttonup = false;
-    },
-    releaseButton: function() {
-        this._buttonup = true;
-    },
-
-    keydown: function(ev) {
-        if (ev.keyCode === 32) {
-            this._manipulator.computeHomePosition();
-            ev.preventDefault();
-        } else if (ev.keyCode === this._panKey && this.getMode() !== OrbitManipulator.Pan) {
-            this.setMode(OrbitManipulator.Pan);
-            this._manipulator.getPanInterpolator().reset();
-            this.pushButton();
-            ev.preventDefault();
-        } else if (ev.keyCode === this._zoomKey && this.getMode() !== OrbitManipulator.Zoom) {
-            this.setMode(OrbitManipulator.Zoom);
-            this._manipulator.getZoomInterpolator().reset();
-            this.pushButton();
-            ev.preventDefault();
-        } else if (ev.keyCode === this._rotateKey && this.getMode() !== OrbitManipulator.Rotate) {
-            this.setMode(OrbitManipulator.Rotate);
-            this._manipulator.getRotateInterpolator().reset();
-            this.pushButton();
-            ev.preventDefault();
-        }
-    },
-
-    keyup: function(ev) {
-        if (ev.keyCode === this._panKey) {
-            this.mouseup(ev);
-        } else if (ev.keyCode === this._rotateKey) {
-            this.mouseup(ev);
-        } else if (ev.keyCode === this._rotateKey) {
-            this.mouseup(ev);
-        }
-        this.setMode(undefined);
-    }
-};
+    })
+);
 
 export default CADManipulatorStandardMouseKeyboardController;

--- a/sources/osgGA/Controller.js
+++ b/sources/osgGA/Controller.js
@@ -1,0 +1,23 @@
+var Controller = function(manipulator) {
+    this._manipulator = manipulator;
+    this._enable = true;
+};
+
+Controller.prototype = {
+
+    // All eventProxy must check isEnabled before injecting
+    // event into Controllers
+    isEnabled: function() {
+        return this._enable;
+    },
+
+    // called to enable/disable a Controller
+    // it should be customized for controller that keeps states
+    // on events
+    setEnable: function(bool) {
+        this._enable = bool;
+    }
+
+};
+
+export default Controller;

--- a/sources/osgGA/FirstPersonManipulatorDeviceOrientationController.js
+++ b/sources/osgGA/FirstPersonManipulatorDeviceOrientationController.js
@@ -1,5 +1,7 @@
-import { quat } from 'osg/glMatrix';
-import { vec3 } from 'osg/glMatrix';
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+import {quat} from 'osg/glMatrix';
+import {vec3} from 'osg/glMatrix';
 
 var degtorad = Math.PI / 180.0; // Degree-to-Radian conversion
 
@@ -50,7 +52,7 @@ var makeRotateFromEuler = function(q, x, y, z, order) {
 };
 
 var FirstPersonManipulatorDeviceOrientationController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
@@ -106,21 +108,24 @@ FirstPersonManipulatorDeviceOrientationController.computeQuaternion = (function(
     };
 })();
 
-FirstPersonManipulatorDeviceOrientationController.prototype = {
-    init: function() {
-        this._stepFactor = 1.0; // meaning radius*stepFactor to move
-        this._quat = quat.create();
-        this._pos = vec3.create();
-    },
+utils.createPrototypeObject(
+    FirstPersonManipulatorDeviceOrientationController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._stepFactor = 1.0; // meaning radius*stepFactor to move
+            this._quat = quat.create();
+            this._pos = vec3.create();
+        },
 
-    update: function(deviceOrientation, screenOrientation) {
-        FirstPersonManipulatorDeviceOrientationController.computeQuaternion(
-            this._quat,
-            deviceOrientation,
-            screenOrientation
-        );
-        this._manipulator.setPoseVR(this._quat, this._pos);
-    }
-};
+        update: function(deviceOrientation, screenOrientation) {
+            FirstPersonManipulatorDeviceOrientationController.computeQuaternion(
+                this._quat,
+                deviceOrientation,
+                screenOrientation
+            );
+            this._manipulator.setPoseVR(this._quat, this._pos);
+        }
+    })
+);
 
 export default FirstPersonManipulatorDeviceOrientationController;

--- a/sources/osgGA/FirstPersonManipulatorStandardMouseKeyboardController.js
+++ b/sources/osgGA/FirstPersonManipulatorStandardMouseKeyboardController.js
@@ -1,119 +1,134 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+
 var FirstPersonManipulatorStandardMouseKeyboardController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-FirstPersonManipulatorStandardMouseKeyboardController.prototype = {
-    init: function() {
-        this.releaseButton();
-        this._delay = 0.15;
-        this._stepFactor = 1.0; // meaning radius*stepFactor to move
-    },
-    setEventProxy: function(proxy) {
-        this._eventProxy = proxy;
-    },
-    setManipulator: function(manipulator) {
-        this._manipulator = manipulator;
+utils.createPrototypeObject(
+    FirstPersonManipulatorStandardMouseKeyboardController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this.releaseButton();
+            this._delay = 0.15;
+            this._stepFactor = 1.0; // meaning radius*stepFactor to move
+            this._buttonup = false;
+        },
+        // called to enable/disable controller
+        setEnable: function(bool) {
+            if (!bool) {
+                // reset mode if we disable it
+                this._buttonup = false;
+            }
+            Controller.prototype.setEnable.call(this, bool);
+        },
+        setEventProxy: function(proxy) {
+            this._eventProxy = proxy;
+        },
+        setManipulator: function(manipulator) {
+            this._manipulator = manipulator;
 
-        // we always want to sync speed of controller with manipulator
-        this._manipulator.setStepFactor(this._stepFactor);
-    },
+            // we always want to sync speed of controller with manipulator
+            this._manipulator.setStepFactor(this._stepFactor);
+        },
 
-    pushButton: function() {
-        this._buttonup = false;
-    },
-    releaseButton: function() {
-        this._buttonup = true;
-    },
+        pushButton: function() {
+            this._buttonup = false;
+        },
+        releaseButton: function() {
+            this._buttonup = true;
+        },
 
-    mousedown: function(ev) {
-        var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
-        var manipulator = this._manipulator;
-        manipulator.getLookPositionInterpolator().set(pos[0], pos[1]);
-        this.pushButton();
-    },
-    mouseup: function(/*ev */) {
-        this.releaseButton();
-    },
-    mouseout: function(/*ev */) {
-        this.releaseButton();
-    },
-    mousemove: function(ev) {
-        if (this._buttonup === true) {
-            return;
+        mousedown: function(ev) {
+            var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
+            var manipulator = this._manipulator;
+            manipulator.getLookPositionInterpolator().set(pos[0], pos[1]);
+            this.pushButton();
+        },
+        mouseup: function(/*ev */) {
+            this.releaseButton();
+        },
+        mouseout: function(/*ev */) {
+            this.releaseButton();
+        },
+        mousemove: function(ev) {
+            if (this._buttonup === true) {
+                return;
+            }
+
+            var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
+            this._manipulator.getLookPositionInterpolator().setDelay(this._delay);
+            this._manipulator.getLookPositionInterpolator().setTarget(pos[0], pos[1]);
+
+            ev.preventDefault();
+        },
+        mousewheel: function(ev, intDelta /*, deltaX, deltaY */) {
+            this._stepFactor = Math.min(Math.max(0.001, this._stepFactor + intDelta * 0.01), 4.0);
+            this._manipulator.setStepFactor(this._stepFactor);
+        },
+
+        keydown: function(event) {
+            var manipulator = this._manipulator;
+            if (event.keyCode === 32) {
+                manipulator.computeHomePosition();
+                event.preventDefault();
+            } else if (event.keyCode === 87 || event.keyCode === 90 || event.keyCode === 38) {
+                // w/z/up
+                manipulator.getForwardInterpolator().setDelay(this._delay);
+                manipulator.getForwardInterpolator().setTarget(1);
+                event.preventDefault();
+                return false;
+            } else if (event.keyCode === 83 || event.keyCode === 40) {
+                // S/down
+                manipulator.getForwardInterpolator().setDelay(this._delay);
+                manipulator.getForwardInterpolator().setTarget(-1);
+                event.preventDefault();
+                return false;
+            } else if (event.keyCode === 68 || event.keyCode === 39) {
+                // D/right
+                manipulator.getSideInterpolator().setDelay(this._delay);
+                manipulator.getSideInterpolator().setTarget(1);
+                event.preventDefault();
+                return false;
+            } else if (event.keyCode === 65 || event.keyCode === 81 || event.keyCode === 37) {
+                // a/q/left
+                manipulator.getSideInterpolator().setDelay(this._delay);
+                manipulator.getSideInterpolator().setTarget(-1);
+                event.preventDefault();
+                return false;
+            }
+            return undefined;
+        },
+
+        keyup: function(event) {
+            var manipulator = this._manipulator;
+            if (
+                event.keyCode === 87 ||
+                event.keyCode === 90 ||
+                event.keyCode === 38 || // w/z/up
+                event.keyCode === 83 ||
+                event.keyCode === 40
+            ) {
+                // S/down
+                manipulator.getForwardInterpolator().setDelay(this._delay);
+                manipulator.getForwardInterpolator().setTarget(0);
+                return false;
+            } else if (
+                event.keyCode === 68 ||
+                event.keyCode === 39 || // D/right
+                event.keyCode === 65 ||
+                event.keyCode === 81 ||
+                event.keyCode === 37
+            ) {
+                // a/q/left
+                manipulator.getSideInterpolator().setDelay(this._delay);
+                manipulator.getSideInterpolator().setTarget(0);
+                return false;
+            }
+            return undefined;
         }
-
-        var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
-        this._manipulator.getLookPositionInterpolator().setDelay(this._delay);
-        this._manipulator.getLookPositionInterpolator().setTarget(pos[0], pos[1]);
-
-        ev.preventDefault();
-    },
-    mousewheel: function(ev, intDelta /*, deltaX, deltaY */) {
-        this._stepFactor = Math.min(Math.max(0.001, this._stepFactor + intDelta * 0.01), 4.0);
-        this._manipulator.setStepFactor(this._stepFactor);
-    },
-
-    keydown: function(event) {
-        var manipulator = this._manipulator;
-        if (event.keyCode === 32) {
-            manipulator.computeHomePosition();
-            event.preventDefault();
-        } else if (event.keyCode === 87 || event.keyCode === 90 || event.keyCode === 38) {
-            // w/z/up
-            manipulator.getForwardInterpolator().setDelay(this._delay);
-            manipulator.getForwardInterpolator().setTarget(1);
-            event.preventDefault();
-            return false;
-        } else if (event.keyCode === 83 || event.keyCode === 40) {
-            // S/down
-            manipulator.getForwardInterpolator().setDelay(this._delay);
-            manipulator.getForwardInterpolator().setTarget(-1);
-            event.preventDefault();
-            return false;
-        } else if (event.keyCode === 68 || event.keyCode === 39) {
-            // D/right
-            manipulator.getSideInterpolator().setDelay(this._delay);
-            manipulator.getSideInterpolator().setTarget(1);
-            event.preventDefault();
-            return false;
-        } else if (event.keyCode === 65 || event.keyCode === 81 || event.keyCode === 37) {
-            // a/q/left
-            manipulator.getSideInterpolator().setDelay(this._delay);
-            manipulator.getSideInterpolator().setTarget(-1);
-            event.preventDefault();
-            return false;
-        }
-        return undefined;
-    },
-
-    keyup: function(event) {
-        var manipulator = this._manipulator;
-        if (
-            event.keyCode === 87 ||
-            event.keyCode === 90 ||
-            event.keyCode === 38 || // w/z/up
-            event.keyCode === 83 ||
-            event.keyCode === 40
-        ) {
-            // S/down
-            manipulator.getForwardInterpolator().setDelay(this._delay);
-            manipulator.getForwardInterpolator().setTarget(0);
-            return false;
-        } else if (
-            event.keyCode === 68 ||
-            event.keyCode === 39 || // D/right
-            event.keyCode === 65 ||
-            event.keyCode === 81 ||
-            event.keyCode === 37
-        ) {
-            // a/q/left
-            manipulator.getSideInterpolator().setDelay(this._delay);
-            manipulator.getSideInterpolator().setTarget(0);
-            return false;
-        }
-        return undefined;
-    }
-};
+    })
+);
 
 export default FirstPersonManipulatorStandardMouseKeyboardController;

--- a/sources/osgGA/FirstPersonManipulatorWebVRController.js
+++ b/sources/osgGA/FirstPersonManipulatorWebVRController.js
@@ -1,13 +1,19 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+
 var FirstPersonManipulatorWebVRController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-FirstPersonManipulatorWebVRController.prototype = {
-    init: function() {},
-    update: function(q, position) {
-        this._manipulator.setPoseVR(q, position);
-    }
-};
+utils.createPrototypeObject(
+    FirstPersonManipulatorWebVRController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {},
+        update: function(q, position) {
+            this._manipulator.setPoseVR(q, position);
+        }
+    })
+);
 
 export default FirstPersonManipulatorWebVRController;

--- a/sources/osgGA/OrbitManipulatorDeviceOrientationController.js
+++ b/sources/osgGA/OrbitManipulatorDeviceOrientationController.js
@@ -1,29 +1,34 @@
-import { quat } from 'osg/glMatrix';
-import { vec3 } from 'osg/glMatrix';
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+import {quat} from 'osg/glMatrix';
+import {vec3} from 'osg/glMatrix';
 
 import FirstPersonDeviceOrientation from 'osgGA/FirstPersonManipulatorDeviceOrientationController';
 
 var OrbitManipulatorDeviceOrientationController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-OrbitManipulatorDeviceOrientationController.prototype = {
-    init: function() {
-        this._stepFactor = 1.0; // meaning radius*stepFactor to move
-        this._quat = quat.create();
-        this._pos = vec3.create();
-    },
+utils.createPrototypeObject(
+    OrbitManipulatorDeviceOrientationController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._stepFactor = 1.0; // meaning radius*stepFactor to move
+            this._quat = quat.create();
+            this._pos = vec3.create();
+        },
 
-    update: function(deviceOrientation, screenOrientation) {
-        // for now we use the same code in first person and orbit to compute rotation
-        FirstPersonDeviceOrientation.computeQuaternion(
-            this._quat,
-            deviceOrientation,
-            screenOrientation
-        );
-        this._manipulator.setPoseVR(this._quat, this._pos);
-    }
-};
+        update: function(deviceOrientation, screenOrientation) {
+            // for now we use the same code in first person and orbit to compute rotation
+            FirstPersonDeviceOrientation.computeQuaternion(
+                this._quat,
+                deviceOrientation,
+                screenOrientation
+            );
+            this._manipulator.setPoseVR(this._quat, this._pos);
+        }
+    })
+);
 
 export default OrbitManipulatorDeviceOrientationController;

--- a/sources/osgGA/OrbitManipulatorGamePadController.js
+++ b/sources/osgGA/OrbitManipulatorGamePadController.js
@@ -1,110 +1,114 @@
-import { vec2 } from 'osg/glMatrix';
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+import {vec2} from 'osg/glMatrix';
 
 var OrbitManipulatorGamePadController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-OrbitManipulatorGamePadController.prototype = {
-    init: function() {
-        this._delay = 0.15;
-        this._threshold = 0.08;
-        this._mode = 0;
-        this._padFactor = 10.0;
-        this._zoomFactor = 0.5;
-        this._rotateFactor = 5.0;
-    },
+utils.createPrototypeObject(
+    OrbitManipulatorGamePadController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._delay = 0.15;
+            this._threshold = 0.08;
+            this._padFactor = 10.0;
+            this._zoomFactor = 0.5;
+            this._rotateFactor = 5.0;
+        },
 
-    addPan: function(pan, x, y) {
-        pan.setDelay(this._delay);
-        pan.addTarget(x * this._padFactor, y * this._padFactor);
-    },
-
-    addZoom: function(zoom, z) {
-        zoom.setDelay(this._delay);
-        zoom.addTarget(z * this._zoomFactor);
-    },
-
-    addRotate: function(rotate, x, y) {
-        rotate.setDelay(this._delay);
-        //var rotateTarget = rotate.getTarget();
-        rotate.addTarget(x * this._rotateFactor, y * this._rotateFactor);
-    },
-
-    gamepadaxes: function(axes) {
-        // Block badly balanced controllers
-        var AXIS_THRESHOLD = 0.005;
-
-        //var rotateTarget, panTarget;
-        var rotate = this._manipulator.getRotateInterpolator();
-        var zoom = this._manipulator.getZoomInterpolator();
-        var pan = this._manipulator.getPanInterpolator();
-        // Regular gamepads
-        if (axes.length === 4) {
-            if (Math.abs(axes[0]) > AXIS_THRESHOLD || Math.abs(axes[1]) > AXIS_THRESHOLD) {
-                this.addRotate(rotate, -axes[0], axes[1]);
-            }
-            if (Math.abs(axes[3]) > AXIS_THRESHOLD) {
-                this.addZoom(zoom, -axes[3]);
-            }
-
-            //SpaceNavigator & 6-axis controllers
-        } else if (axes.length >= 5) {
-            //Notify.log(axes);
-            if (Math.abs(axes[0]) > AXIS_THRESHOLD || Math.abs(axes[1]) > AXIS_THRESHOLD) {
-                this.addPan(pan, -axes[0], axes[1]);
-            }
-
-            if (Math.abs(axes[2]) > AXIS_THRESHOLD) {
-                this.addZoom(zoom, -axes[2]);
-            }
-
-            if (Math.abs(axes[3]) > AXIS_THRESHOLD || Math.abs(axes[4]) > AXIS_THRESHOLD) {
-                this.addRotate(rotate, axes[4], axes[3]);
-            }
-        }
-    },
-
-    gamepadbuttondown: function(event /*, pressed */) {
-        // Buttons 12 to 15 are the d-pad.
-        if (event.button >= 12 && event.button <= 15) {
-            var pan = this._manipulator.getPanInterpolator();
-            var panTarget = pan.getTarget();
-            var delta = {
-                12: vec2.fromValues(0, -1),
-                13: vec2.fromValues(0, 1),
-                14: vec2.fromValues(-1, 0),
-                15: vec2.fromValues(1, 0)
-            }[event.button];
+        addPan: function(pan, x, y) {
             pan.setDelay(this._delay);
-            pan.setTarget(panTarget[0] - delta[0] * 10, panTarget[1] + delta[1] * 10);
-        }
-    },
+            pan.addTarget(x * this._padFactor, y * this._padFactor);
+        },
 
-    update: function(gm) {
-        if (!gm) {
-            return;
-        }
+        addZoom: function(zoom, z) {
+            zoom.setDelay(this._delay);
+            zoom.addTarget(z * this._zoomFactor);
+        },
 
-        var axis = gm.axes;
-        var buttons = gm.buttons;
+        addRotate: function(rotate, x, y) {
+            rotate.setDelay(this._delay);
+            //var rotateTarget = rotate.getTarget();
+            rotate.addTarget(x * this._rotateFactor, y * this._rotateFactor);
+        },
 
-        this.gamepadaxes(axis);
+        gamepadaxes: function(axes) {
+            // Block badly balanced controllers
+            var AXIS_THRESHOLD = 0.005;
 
-        // Dummy event wrapper
-        var emptyFunc = function() {};
-        for (var i = 0; i < buttons.length; i++) {
-            if (buttons[i]) {
-                this.gamepadbuttondown(
-                    {
-                        preventDefault: emptyFunc,
-                        gamepad: gm,
-                        button: i
-                    },
-                    !!buttons[i]
-                );
+            //var rotateTarget, panTarget;
+            var rotate = this._manipulator.getRotateInterpolator();
+            var zoom = this._manipulator.getZoomInterpolator();
+            var pan = this._manipulator.getPanInterpolator();
+            // Regular gamepads
+            if (axes.length === 4) {
+                if (Math.abs(axes[0]) > AXIS_THRESHOLD || Math.abs(axes[1]) > AXIS_THRESHOLD) {
+                    this.addRotate(rotate, -axes[0], axes[1]);
+                }
+                if (Math.abs(axes[3]) > AXIS_THRESHOLD) {
+                    this.addZoom(zoom, -axes[3]);
+                }
+
+                //SpaceNavigator & 6-axis controllers
+            } else if (axes.length >= 5) {
+                //Notify.log(axes);
+                if (Math.abs(axes[0]) > AXIS_THRESHOLD || Math.abs(axes[1]) > AXIS_THRESHOLD) {
+                    this.addPan(pan, -axes[0], axes[1]);
+                }
+
+                if (Math.abs(axes[2]) > AXIS_THRESHOLD) {
+                    this.addZoom(zoom, -axes[2]);
+                }
+
+                if (Math.abs(axes[3]) > AXIS_THRESHOLD || Math.abs(axes[4]) > AXIS_THRESHOLD) {
+                    this.addRotate(rotate, axes[4], axes[3]);
+                }
+            }
+        },
+
+        gamepadbuttondown: function(event /*, pressed */) {
+            // Buttons 12 to 15 are the d-pad.
+            if (event.button >= 12 && event.button <= 15) {
+                var pan = this._manipulator.getPanInterpolator();
+                var panTarget = pan.getTarget();
+                var delta = {
+                    12: vec2.fromValues(0, -1),
+                    13: vec2.fromValues(0, 1),
+                    14: vec2.fromValues(-1, 0),
+                    15: vec2.fromValues(1, 0)
+                }[event.button];
+                pan.setDelay(this._delay);
+                pan.setTarget(panTarget[0] - delta[0] * 10, panTarget[1] + delta[1] * 10);
+            }
+        },
+
+        update: function(gm) {
+            if (!gm) {
+                return;
+            }
+
+            var axis = gm.axes;
+            var buttons = gm.buttons;
+
+            this.gamepadaxes(axis);
+
+            // Dummy event wrapper
+            var emptyFunc = function() {};
+            for (var i = 0; i < buttons.length; i++) {
+                if (buttons[i]) {
+                    this.gamepadbuttondown(
+                        {
+                            preventDefault: emptyFunc,
+                            gamepad: gm,
+                            button: i
+                        },
+                        !!buttons[i]
+                    );
+                }
             }
         }
-    }
-};
+    })
+);
 export default OrbitManipulatorGamePadController;

--- a/sources/osgGA/OrbitManipulatorHammerController.js
+++ b/sources/osgGA/OrbitManipulatorHammerController.js
@@ -1,212 +1,218 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
 import osgMath from 'osg/math';
 
 var OrbitManipulatorHammerController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-OrbitManipulatorHammerController.prototype = {
-    init: function() {
-        this._panFactorX = 1.0;
-        this._panFactorY = -this._panFactorX;
+utils.createPrototypeObject(
+    OrbitManipulatorHammerController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._panFactorX = 1.0;
+            this._panFactorY = -this._panFactorX;
 
-        this._rotateFactorX = 0.6;
-        this._rotateFactorY = -this._rotateFactorX;
-        this._zoomFactor = 5.0;
+            this._rotateFactorX = 0.6;
+            this._rotateFactorY = -this._rotateFactorX;
+            this._zoomFactor = 5.0;
 
-        this._lastScale = 0;
-        this._nbPointerLast = 0; // to check if we the number of pointers has changed
-        this._delay = 0.15;
+            this._lastScale = 0;
+            this._nbPointerLast = 0; // to check if we the number of pointers has changed
+            this._delay = 0.15;
 
-        this._transformStarted = false;
-        this._dragStarted = false;
+            this._transformStarted = false;
+            this._dragStarted = false;
 
-        this._cbPanStart = this.panStart.bind(this);
-        this._cbPanMove = this.panMove.bind(this);
-        this._cbPanEnd = this.panEnd.bind(this);
+            this._cbPanStart = this.panStart.bind(this);
+            this._cbPanMove = this.panMove.bind(this);
+            this._cbPanEnd = this.panEnd.bind(this);
 
-        this._cbPinchStart = this.pinchStart.bind(this);
-        this._cbPinchEnd = this.pinchEnd.bind(this);
-        this._cbPinchInOut = this.pinchInOut.bind(this);
+            this._cbPinchStart = this.pinchStart.bind(this);
+            this._cbPinchEnd = this.pinchEnd.bind(this);
+            this._cbPinchInOut = this.pinchInOut.bind(this);
 
-        this._isValid = true;
-    },
+            this._isValid = true;
+        },
 
-    setValid: function(valid) {
-        if (valid === this._isValid) return;
-        this._isValid = valid;
-        // if validity change during a drag/transform
-        this._transformStarted = false;
-        this._dragStarterd = false;
-    },
+        setValid: function(valid) {
+            if (valid === this._isValid) return;
+            this._isValid = valid;
+            // if validity change during a drag/transform
+            this._transformStarted = false;
+            this._dragStarted = false;
+        },
 
-    getPanStartBind: function() {
-        return this._cbPanStart;
-    },
+        getPanStartBind: function() {
+            return this._cbPanStart;
+        },
 
-    getPanMoveBind: function() {
-        return this._cbPanMove;
-    },
+        getPanMoveBind: function() {
+            return this._cbPanMove;
+        },
 
-    getPanEndBind: function() {
-        return this._cbPanEnd;
-    },
+        getPanEndBind: function() {
+            return this._cbPanEnd;
+        },
 
-    getPinchEndBind: function() {
-        return this._cbPinchEnd;
-    },
+        getPinchEndBind: function() {
+            return this._cbPinchEnd;
+        },
 
-    _setListeners: function() {
-        var hammer = this._eventProxy;
+        _setListeners: function() {
+            var hammer = this._eventProxy;
 
-        // Let the pan be detected with two fingers.
-        // 2 => pan, 1 -> rotate
-        hammer.get('pan').set({
-            threshold: 0,
-            pointers: 0
-        });
-
-        var pinch = hammer.get('pinch');
-        if (pinch) {
-            // Set a minimal thresold on pinch event, to be detected after pan
-            pinch.set({
-                threshold: 0.1
+            // Let the pan be detected with two fingers.
+            // 2 => pan, 1 -> rotate
+            hammer.get('pan').set({
+                threshold: 0,
+                pointers: 0
             });
-            pinch.recognizeWith(hammer.get('pan'));
+
+            var pinch = hammer.get('pinch');
+            if (pinch) {
+                // Set a minimal thresold on pinch event, to be detected after pan
+                pinch.set({
+                    threshold: 0.1
+                });
+                pinch.recognizeWith(hammer.get('pan'));
+            }
+
+            hammer.on('panstart ', this._cbPanStart);
+            hammer.on('panmove', this._cbPanMove);
+            hammer.on('panend', this._cbPanEnd);
+
+            hammer.on('pinchend', this._cbPinchEnd);
+            hammer.on('pinchstart', this._cbPinchStart);
+            hammer.on('pinchin pinchout', this._cbPinchInOut);
+
+            // if validity change during a drag/tranform
+            this._transformStarted = false;
+            this._dragStarted = false;
+        },
+
+        setEventProxy: function(hammer) {
+            if (!hammer || hammer === this._eventProxy) {
+                return;
+            }
+
+            this._eventProxy = hammer;
+            if (this._manipulator) this._setListeners();
+        },
+
+        _computeTouches: function(event) {
+            if (event.pointers !== undefined) return event.pointers.length;
+            return 1; // mouse
+        },
+
+        panStart: function(event) {
+            if (!this._isValid || this._transformStarted || event.pointerType === 'mouse') {
+                return;
+            }
+
+            this._dragStarted = true;
+            var manipulator = this._manipulator;
+            this._nbPointerLast = this._computeTouches(event);
+            if (this._nbPointerLast === 2) {
+                var panInterpolator = manipulator.getPanInterpolator();
+                panInterpolator.reset();
+                var xPan = event.center.x * this._panFactorX;
+                var yPan = event.center.y * this._panFactorY;
+                panInterpolator.set(xPan, yPan);
+            } else {
+                var rotateInterpolator = manipulator.getRotateInterpolator();
+                rotateInterpolator.reset();
+                var xRot = event.center.x * this._rotateFactorX;
+                var yRot = event.center.y * this._rotateFactorY;
+                rotateInterpolator.set(xRot, yRot);
+            }
+        },
+
+        panMove: function(event) {
+            if (!this._isValid || !this._dragStarted || event.pointerType === 'mouse') {
+                return;
+            }
+
+            var manipulator = this._manipulator;
+            var nbPointers = this._computeTouches(event);
+            // prevent sudden big changes in the event.center variables
+            if (this._nbPointerLast !== nbPointers) {
+                if (nbPointers === 2) manipulator.getPanInterpolator().reset();
+                else manipulator.getRotateInterpolator().reset();
+                this._nbPointerLast = nbPointers;
+            }
+
+            if (nbPointers === 2) {
+                var panInterpolator = manipulator.getPanInterpolator();
+                var xPan = event.center.x * this._panFactorX;
+                var yPan = event.center.y * this._panFactorY;
+                panInterpolator.setTarget(xPan, yPan);
+            } else {
+                var rotateInterpolator = manipulator.getRotateInterpolator();
+                rotateInterpolator.setDelay(this._delay);
+                var xRot = event.center.x * this._rotateFactorX;
+                var yRot = event.center.y * this._rotateFactorY;
+                rotateInterpolator.setTarget(xRot, yRot);
+            }
+        },
+
+        panEnd: function(event) {
+            if (!this._isValid || !this._dragStarted || event.pointerType === 'mouse') return;
+            this._dragStarted = false;
+        },
+
+        pinchStart: function(event) {
+            if (!this._isValid || event.pointerType === 'mouse') return;
+
+            this._transformStarted = true;
+            this._lastScale = event.scale;
+            var zoomInterpolator = this._manipulator.getZoomInterpolator();
+            zoomInterpolator.reset();
+            zoomInterpolator.set(this._lastScale);
+            event.preventDefault();
+        },
+
+        pinchEnd: function(event) {
+            if (!this._isValid || event.pointerType === 'mouse') return;
+            this._transformStarted = false;
+        },
+
+        pinchInOut: function(event) {
+            if (!this._isValid || !this._transformStarted || event.pointerType === 'mouse') return;
+
+            // make the dezoom faster (because the manipulator dezoom/dezoom distance speed is adaptive)
+            var zoomFactor =
+                event.scale > this._lastScale ? this._zoomFactor : this._zoomFactor * 3.0;
+            // also detect pan (velocity) to reduce zoom force
+            var minDezoom = 0.0;
+            var maxDezoom = 0.5;
+            var aSmooth = -Math.abs(event.velocity) + (minDezoom + maxDezoom);
+            zoomFactor *= osgMath.smoothStep(minDezoom, maxDezoom, aSmooth);
+
+            var scale = (event.scale - this._lastScale) * zoomFactor;
+            this._lastScale = event.scale;
+
+            var zoomInterpolator = this._manipulator.getZoomInterpolator();
+            zoomInterpolator.setTarget(zoomInterpolator.getTarget()[0] - scale);
+        },
+
+        removeEventProxy: function(eventProxy) {
+            var proxy = eventProxy || this._eventProxy;
+            if (!proxy) return;
+
+            proxy.off('panstart ', this._cbPanStart);
+            proxy.off('panmove', this._cbPanMove);
+            proxy.off('panend', this._cbPanEnd);
+            proxy.off('pinchstart', this._cbPinchStart);
+            proxy.off('pinchend', this._cbPinchEnd);
+            proxy.off('pinchin pinchout', this._cbPinchInOut);
+        },
+
+        setManipulator: function(manipulator) {
+            this._manipulator = manipulator;
+            if (this._eventProxy) this._setListeners();
         }
-
-        hammer.on('panstart ', this._cbPanStart);
-        hammer.on('panmove', this._cbPanMove);
-        hammer.on('panend', this._cbPanEnd);
-
-        hammer.on('pinchend', this._cbPinchEnd);
-        hammer.on('pinchstart', this._cbPinchStart);
-        hammer.on('pinchin pinchout', this._cbPinchInOut);
-
-        // if validity change during a drag/tranform
-        this._transformStarted = false;
-        this._dragStarterd = false;
-    },
-
-    setEventProxy: function(hammer) {
-        if (!hammer || hammer === this._eventProxy) {
-            return;
-        }
-
-        this._eventProxy = hammer;
-        if (this._manipulator) this._setListeners();
-    },
-
-    _computeTouches: function(event) {
-        if (event.pointers !== undefined) return event.pointers.length;
-        return 1; // mouse
-    },
-
-    panStart: function(event) {
-        if (!this._isValid || this._transformStarted || event.pointerType === 'mouse') {
-            return;
-        }
-
-        this._dragStarted = true;
-        var manipulator = this._manipulator;
-        this._nbPointerLast = this._computeTouches(event);
-        if (this._nbPointerLast === 2) {
-            var panInterpolator = manipulator.getPanInterpolator();
-            panInterpolator.reset();
-            var xPan = event.center.x * this._panFactorX;
-            var yPan = event.center.y * this._panFactorY;
-            panInterpolator.set(xPan, yPan);
-        } else {
-            var rotateInterpolator = manipulator.getRotateInterpolator();
-            rotateInterpolator.reset();
-            var xRot = event.center.x * this._rotateFactorX;
-            var yRot = event.center.y * this._rotateFactorY;
-            rotateInterpolator.set(xRot, yRot);
-        }
-    },
-
-    panMove: function(event) {
-        if (!this._isValid || !this._dragStarted || event.pointerType === 'mouse') {
-            return;
-        }
-
-        var manipulator = this._manipulator;
-        var nbPointers = this._computeTouches(event);
-        // prevent sudden big changes in the event.center variables
-        if (this._nbPointerLast !== nbPointers) {
-            if (nbPointers === 2) manipulator.getPanInterpolator().reset();
-            else manipulator.getRotateInterpolator().reset();
-            this._nbPointerLast = nbPointers;
-        }
-
-        if (nbPointers === 2) {
-            var panInterpolator = manipulator.getPanInterpolator();
-            var xPan = event.center.x * this._panFactorX;
-            var yPan = event.center.y * this._panFactorY;
-            panInterpolator.setTarget(xPan, yPan);
-        } else {
-            var rotateInterpolator = manipulator.getRotateInterpolator();
-            rotateInterpolator.setDelay(this._delay);
-            var xRot = event.center.x * this._rotateFactorX;
-            var yRot = event.center.y * this._rotateFactorY;
-            rotateInterpolator.setTarget(xRot, yRot);
-        }
-    },
-
-    panEnd: function(event) {
-        if (!this._isValid || !this._dragStarted || event.pointerType === 'mouse') return;
-        this._dragStarted = false;
-    },
-
-    pinchStart: function(event) {
-        if (!this._isValid || event.pointerType === 'mouse') return;
-
-        this._transformStarted = true;
-        this._lastScale = event.scale;
-        var zoomInterpolator = this._manipulator.getZoomInterpolator();
-        zoomInterpolator.reset();
-        zoomInterpolator.set(this._lastScale);
-        event.preventDefault();
-    },
-
-    pinchEnd: function(event) {
-        if (!this._isValid || event.pointerType === 'mouse') return;
-        this._transformStarted = false;
-    },
-
-    pinchInOut: function(event) {
-        if (!this._isValid || !this._transformStarted || event.pointerType === 'mouse') return;
-
-        // make the dezoom faster (because the manipulator dezoom/dezoom distance speed is adaptive)
-        var zoomFactor = event.scale > this._lastScale ? this._zoomFactor : this._zoomFactor * 3.0;
-        // also detect pan (velocity) to reduce zoom force
-        var minDezoom = 0.0;
-        var maxDezoom = 0.5;
-        var aSmooth = -Math.abs(event.velocity) + (minDezoom + maxDezoom);
-        zoomFactor *= osgMath.smoothStep(minDezoom, maxDezoom, aSmooth);
-
-        var scale = (event.scale - this._lastScale) * zoomFactor;
-        this._lastScale = event.scale;
-
-        var zoomInterpolator = this._manipulator.getZoomInterpolator();
-        zoomInterpolator.setTarget(zoomInterpolator.getTarget()[0] - scale);
-    },
-
-    removeEventProxy: function(eventProxy) {
-        var proxy = eventProxy || this._eventProxy;
-        if (!proxy) return;
-
-        proxy.off('panstart ', this._cbPanStart);
-        proxy.off('panmove', this._cbPanMove);
-        proxy.off('panend', this._cbPanEnd);
-        proxy.off('pinchstart', this._cbPinchStart);
-        proxy.off('pinchend', this._cbPinchEnd);
-        proxy.off('pinchin pinchout', this._cbPinchInOut);
-    },
-
-    setManipulator: function(manipulator) {
-        this._manipulator = manipulator;
-        if (this._eventProxy) this._setListeners();
-    }
-};
+    })
+);
 export default OrbitManipulatorHammerController;

--- a/sources/osgGA/OrbitManipulatorStandardMouseKeyboardController.js
+++ b/sources/osgGA/OrbitManipulatorStandardMouseKeyboardController.js
@@ -1,154 +1,173 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
 import osgMath from 'osg/math';
 import OrbitManipulatorEnums from 'osgGA/orbitManipulatorEnums';
 
 var OrbitManipulatorStandardMouseKeyboardController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-OrbitManipulatorStandardMouseKeyboardController.prototype = {
-    init: function() {
-        this.releaseButton();
-        this._rotateKey = 65; // a
-        this._zoomKey = 83; // s
-        this._panKey = 68; // d
+utils.createPrototypeObject(
+    OrbitManipulatorStandardMouseKeyboardController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {
+            this._rotateKey = 65; // a
+            this._zoomKey = 83; // s
+            this._panKey = 68; // d
 
-        this._mode = undefined;
-        this._delay = 0.15;
-    },
-    getMode: function() {
-        return this._mode;
-    },
-    setMode: function(mode) {
-        this._mode = mode;
-    },
-    setEventProxy: function(proxy) {
-        this._eventProxy = proxy;
-    },
-    setManipulator: function(manipulator) {
-        this._manipulator = manipulator;
-    },
-    mousemove: function(ev) {
-        if (this._buttonup === true) {
-            return;
-        }
-        var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
-        var manipulator = this._manipulator;
-        if (osgMath.isNaN(pos[0]) === false && osgMath.isNaN(pos[1]) === false) {
-            var mode = this.getMode();
-            if (mode === OrbitManipulatorEnums.ROTATE) {
-                manipulator.getRotateInterpolator().setDelay(this._delay);
-                manipulator.getRotateInterpolator().setTarget(pos[0], pos[1]);
-            } else if (mode === OrbitManipulatorEnums.PAN) {
-                manipulator.getPanInterpolator().setTarget(pos[0], pos[1]);
-            } else if (mode === OrbitManipulatorEnums.ZOOM) {
-                var zoom = manipulator.getZoomInterpolator();
-                if (zoom.isReset()) {
+            this._delay = 0.15;
+            this._mode = undefined;
+            this._buttonup = true;
+        },
+        // called to enable/disable controller
+        setEnable: function(bool) {
+            if (!bool) {
+                // reset mode if we disable it
+                this._mode = undefined;
+            }
+            Controller.prototype.setEnable.call(this, bool);
+        },
+        getMode: function() {
+            return this._mode;
+        },
+        setMode: function(mode) {
+            this._mode = mode;
+        },
+        setEventProxy: function(proxy) {
+            this._eventProxy = proxy;
+        },
+        setManipulator: function(manipulator) {
+            this._manipulator = manipulator;
+        },
+        mousemove: function(ev) {
+            if (this._buttonup === true) {
+                return;
+            }
+            var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
+            var manipulator = this._manipulator;
+            if (osgMath.isNaN(pos[0]) === false && osgMath.isNaN(pos[1]) === false) {
+                var mode = this.getMode();
+                if (mode === OrbitManipulatorEnums.ROTATE) {
+                    manipulator.getRotateInterpolator().setDelay(this._delay);
+                    manipulator.getRotateInterpolator().setTarget(pos[0], pos[1]);
+                } else if (mode === OrbitManipulatorEnums.PAN) {
+                    manipulator.getPanInterpolator().setTarget(pos[0], pos[1]);
+                } else if (mode === OrbitManipulatorEnums.ZOOM) {
+                    var zoom = manipulator.getZoomInterpolator();
+                    if (zoom.isReset()) {
+                        zoom.setStart(pos[1]);
+                        zoom.set(0.0);
+                    }
+                    var dy = pos[1] - zoom.getStart();
                     zoom.setStart(pos[1]);
-                    zoom.set(0.0);
-                }
-                var dy = pos[1] - zoom.getStart();
-                zoom.setStart(pos[1]);
-                var v = zoom.getTarget()[0];
-                zoom.setTarget(v - dy / 20.0);
-            }
-        }
-
-        ev.preventDefault();
-    },
-    mousedown: function(ev) {
-        var manipulator = this._manipulator;
-        var mode = this.getMode();
-        if (mode === undefined) {
-            if (ev.button === 0) {
-                if (ev.shiftKey) {
-                    this.setMode(OrbitManipulatorEnums.PAN);
-                } else if (ev.ctrlKey) {
-                    this.setMode(OrbitManipulatorEnums.ZOOM);
-                } else {
-                    this.setMode(OrbitManipulatorEnums.ROTATE);
-                }
-            } else {
-                // For users on Mac machines for who CTRL+LeftClick is naturally converted
-                // into a RightClick in Firefox.
-                if (ev.button === 2 && ev.ctrlKey) {
-                    this.setMode(OrbitManipulatorEnums.ZOOM);
-                } else {
-                    this.setMode(OrbitManipulatorEnums.PAN);
+                    var v = zoom.getTarget()[0];
+                    zoom.setTarget(v - dy / 20.0);
                 }
             }
-        }
 
-        this.pushButton();
-
-        var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
-        mode = this.getMode();
-        if (mode === OrbitManipulatorEnums.ROTATE) {
-            manipulator.getRotateInterpolator().reset();
-            manipulator.getRotateInterpolator().set(pos[0], pos[1]);
-        } else if (mode === OrbitManipulatorEnums.PAN) {
-            manipulator.getPanInterpolator().reset();
-            manipulator.getPanInterpolator().set(pos[0], pos[1]);
-        } else if (mode === OrbitManipulatorEnums.ZOOM) {
-            manipulator.getZoomInterpolator().setStart(pos[1]);
-            manipulator.getZoomInterpolator().set(0.0);
-        }
-    },
-    mouseup: function(/*ev */) {
-        this.releaseButton();
-        this.setMode(undefined);
-    },
-    mouseout: function(/*ev */) {
-        this.releaseButton();
-        this.setMode(undefined);
-    },
-    mousewheel: function(ev, intDelta /*, deltaX, deltaY */) {
-        var manipulator = this._manipulator;
-        var zoomTarget = manipulator.getZoomInterpolator().getTarget()[0] - intDelta;
-        manipulator.getZoomInterpolator().setTarget(zoomTarget);
-    },
-
-    pushButton: function() {
-        this._buttonup = false;
-    },
-    releaseButton: function() {
-        this._buttonup = true;
-    },
-
-    keydown: function(ev) {
-        if (ev.keyCode === 32) {
-            this._manipulator.computeHomePosition();
             ev.preventDefault();
-        } else if (ev.keyCode === this._panKey && this.getMode() !== OrbitManipulatorEnums.PAN) {
-            this.setMode(OrbitManipulatorEnums.PAN);
-            this._manipulator.getPanInterpolator().reset();
+        },
+        mousedown: function(ev) {
+            var manipulator = this._manipulator;
+            var mode = this.getMode();
+            if (mode === undefined) {
+                if (ev.button === 0) {
+                    if (ev.shiftKey) {
+                        this.setMode(OrbitManipulatorEnums.PAN);
+                    } else if (ev.ctrlKey) {
+                        this.setMode(OrbitManipulatorEnums.ZOOM);
+                    } else {
+                        this.setMode(OrbitManipulatorEnums.ROTATE);
+                    }
+                } else {
+                    // For users on Mac machines for who CTRL+LeftClick is naturally converted
+                    // into a RightClick in Firefox.
+                    if (ev.button === 2 && ev.ctrlKey) {
+                        this.setMode(OrbitManipulatorEnums.ZOOM);
+                    } else {
+                        this.setMode(OrbitManipulatorEnums.PAN);
+                    }
+                }
+            }
+
             this.pushButton();
-            ev.preventDefault();
-        } else if (ev.keyCode === this._zoomKey && this.getMode() !== OrbitManipulatorEnums.ZOOM) {
-            this.setMode(OrbitManipulatorEnums.ZOOM);
-            this._manipulator.getZoomInterpolator().reset();
-            this.pushButton();
-            ev.preventDefault();
-        } else if (
-            ev.keyCode === this._rotateKey &&
-            this.getMode() !== OrbitManipulatorEnums.ROTATE
-        ) {
-            this.setMode(OrbitManipulatorEnums.ROTATE);
-            this._manipulator.getRotateInterpolator().reset();
-            this.pushButton();
-            ev.preventDefault();
-        }
-    },
 
-    keyup: function(ev) {
-        if (ev.keyCode === this._panKey) {
-            this.mouseup(ev);
-        } else if (ev.keyCode === this._rotateKey) {
-            this.mouseup(ev);
-        } else if (ev.keyCode === this._rotateKey) {
-            this.mouseup(ev);
+            var pos = this._eventProxy.getPositionRelativeToCanvas(ev);
+            mode = this.getMode();
+            if (mode === OrbitManipulatorEnums.ROTATE) {
+                manipulator.getRotateInterpolator().reset();
+                manipulator.getRotateInterpolator().set(pos[0], pos[1]);
+            } else if (mode === OrbitManipulatorEnums.PAN) {
+                manipulator.getPanInterpolator().reset();
+                manipulator.getPanInterpolator().set(pos[0], pos[1]);
+            } else if (mode === OrbitManipulatorEnums.ZOOM) {
+                manipulator.getZoomInterpolator().setStart(pos[1]);
+                manipulator.getZoomInterpolator().set(0.0);
+            }
+        },
+        mouseup: function(/*ev */) {
+            this.releaseButton();
+            this.setMode(undefined);
+        },
+        mouseout: function(/*ev */) {
+            this.releaseButton();
+            this.setMode(undefined);
+        },
+        mousewheel: function(ev, intDelta /*, deltaX, deltaY */) {
+            var manipulator = this._manipulator;
+            var zoomTarget = manipulator.getZoomInterpolator().getTarget()[0] - intDelta;
+            manipulator.getZoomInterpolator().setTarget(zoomTarget);
+        },
+
+        pushButton: function() {
+            this._buttonup = false;
+        },
+        releaseButton: function() {
+            this._buttonup = true;
+        },
+
+        keydown: function(ev) {
+            if (ev.keyCode === 32) {
+                this._manipulator.computeHomePosition();
+                ev.preventDefault();
+            } else if (
+                ev.keyCode === this._panKey &&
+                this.getMode() !== OrbitManipulatorEnums.PAN
+            ) {
+                this.setMode(OrbitManipulatorEnums.PAN);
+                this._manipulator.getPanInterpolator().reset();
+                this.pushButton();
+                ev.preventDefault();
+            } else if (
+                ev.keyCode === this._zoomKey &&
+                this.getMode() !== OrbitManipulatorEnums.ZOOM
+            ) {
+                this.setMode(OrbitManipulatorEnums.ZOOM);
+                this._manipulator.getZoomInterpolator().reset();
+                this.pushButton();
+                ev.preventDefault();
+            } else if (
+                ev.keyCode === this._rotateKey &&
+                this.getMode() !== OrbitManipulatorEnums.ROTATE
+            ) {
+                this.setMode(OrbitManipulatorEnums.ROTATE);
+                this._manipulator.getRotateInterpolator().reset();
+                this.pushButton();
+                ev.preventDefault();
+            }
+        },
+
+        keyup: function(ev) {
+            if (ev.keyCode === this._panKey) {
+                this.mouseup(ev);
+            } else if (ev.keyCode === this._rotateKey) {
+                this.mouseup(ev);
+            } else if (ev.keyCode === this._rotateKey) {
+                this.mouseup(ev);
+            }
+            this.setMode(undefined);
         }
-        this.setMode(undefined);
-    }
-};
+    })
+);
 export default OrbitManipulatorStandardMouseKeyboardController;

--- a/sources/osgGA/OrbitManipulatorWebVRController.js
+++ b/sources/osgGA/OrbitManipulatorWebVRController.js
@@ -1,13 +1,19 @@
+import Controller from 'osgGA/Controller';
+import utils from 'osg/utils';
+
 var OrbitManipulatorWebVRController = function(manipulator) {
-    this._manipulator = manipulator;
+    Controller.call(this, manipulator);
     this.init();
 };
 
-OrbitManipulatorWebVRController.prototype = {
-    init: function() {},
-    update: function(q, position) {
-        this._manipulator.setPoseVR(q, position);
-    }
-};
+utils.createPrototypeObject(
+    OrbitManipulatorWebVRController,
+    utils.objectInherit(Controller.prototype, {
+        init: function() {},
+        update: function(q, position) {
+            this._manipulator.setPoseVR(q, position);
+        }
+    })
+);
 
 export default OrbitManipulatorWebVRController;

--- a/sources/osgStats/Stats.js
+++ b/sources/osgStats/Stats.js
@@ -157,8 +157,6 @@ var Stats = function(viewer, options) {
     this._backgroundPicking = shape.createTexturedQuadGeometry(0, 0, 0, 10, 0, 0, 0, 10, 0);
     this._dragStop = vec2.create();
     this._dragStart = vec2.create();
-    this._eventMouse = viewer._eventProxy.StandardMouseKeyboard;
-    this._eventTouch = viewer._eventProxy.Hammer;
     this._startTransformation = mat4.create();
 
     this._init(options);
@@ -320,10 +318,11 @@ utils.createPrototypeObject(Stats, {
     onMouseDown: function(e) {
         var hits = this.computeNearestIntersection(e);
         this._onStats = !!hits.length;
+        if (!this._onStats) return;
+
+        this._viewer.setEnableManipulator(false);
 
         e.preventDefault();
-        this._eventMouse.setEnable(false);
-        this._eventTouch.setEnable(false);
         mat4.copy(this._startTransformation, this._nodeTransform.getMatrix());
         getCanvasCoord(this._dragStart, e);
         this._dragStop[1] = this._dragStart[1];
@@ -337,17 +336,14 @@ utils.createPrototypeObject(Stats, {
             mat4.translate(
                 this._nodeTransform.getMatrix(),
                 this._startTransformation,
-                vec3.fromValues(0, dy, 0)
+                vec3.fromValues(0, -dy, 0)
             );
         };
     })(),
-    onMouseUp: function(e) {
+    onMouseUp: function() {
+        this._viewer.setEnableManipulator(true);
         this._onStats = false;
-        this._eventMouse.setEnable(true);
-        this._eventTouch.setEnable(true);
-        this._eventMouse.mouseup(e);
     },
-
     computeNearestIntersection: (function() {
         var coord = vec2.create();
         var lsi = new LineSegmentIntersector();

--- a/sources/osgUtil/NodeGizmo.js
+++ b/sources/osgUtil/NodeGizmo.js
@@ -159,10 +159,6 @@ var NodeGizmo = function(viewer) {
     this._iv = new IntersectionVisitor();
     this._iv.setIntersector(this._lsi);
 
-    // disable mouse camera event when interacting with gizmo
-    this._eventMouse = viewer._eventProxy.StandardMouseKeyboard;
-    this._enableMouseBack = false;
-
     this.init();
 };
 
@@ -833,8 +829,7 @@ utils.createPrototypeNode(
 
             e.preventDefault();
 
-            this._enableMouseBack = this._eventMouse.getEnable();
-            this._eventMouse.setEnable(false);
+            this._viewer.setEnableManipulator(false);
 
             this.saveEditMatrices();
             var nm = this._hoverNode.getParents()[0].getNodeMask();
@@ -972,12 +967,7 @@ utils.createPrototypeNode(
         },
 
         onMouseUp: function(e) {
-            if (this._enableMouseBack) {
-                this._enableMouseBack = false;
-                this._eventMouse.setEnable(true);
-                this._eventMouse.mouseup(e);
-            }
-
+            this._viewer.setEnableManipulator(true);
             if (this._debugNode) this._debugNode.setNodeMask(0x0);
 
             var v = vec2.create();

--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -597,6 +597,15 @@ utils.createPrototypeObject(
             View.prototype.setManipulator.call(this, manipulator);
         },
 
+        setEnableManipulator: function(bool) {
+            if (!this._manipulator) return;
+
+            var controllerMap = this._manipulator.getControllerList();
+            for (var name in controllerMap) {
+                controllerMap[name].setEnable(bool);
+            }
+        },
+
         removeEventProxy: function() {
             var list = this._eventProxy;
             for (var key in list) {

--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -245,7 +245,7 @@ utils.createPrototypeObject(
                 return;
             }
 
-            this._stats = new Stats(this.getCamera().getViewport(), options);
+            this._stats = new Stats(this, options);
             this._stats.addConfig(defaultStats);
             this._stats.addConfig(glStats);
             this._stats.addConfig(browserStats);

--- a/sources/osgViewer/eventProxy/DeviceOrientation.js
+++ b/sources/osgViewer/eventProxy/DeviceOrientation.js
@@ -52,7 +52,8 @@ DeviceOrientation.prototype = {
         var manipulator = this._viewer.getManipulator();
         if (!manipulator) return false;
 
-        if (!manipulator.getControllerList()[this._type]) return false;
+        var controller = manipulator.getControllerList()[this._type];
+        if (!controller || !controller.isEnabled()) return false;
 
         return true;
     },

--- a/sources/osgViewer/eventProxy/GamePad.js
+++ b/sources/osgViewer/eventProxy/GamePad.js
@@ -24,8 +24,8 @@ GamePad.prototype = {
         var manipulator = this._viewer.getManipulator();
         if (!manipulator) return false;
 
-        var constrollerList = manipulator.getControllerList();
-        if (!constrollerList[this._type]) return false;
+        var controller = manipulator.getControllerList()[this._type];
+        if (!controller || !controller.isEnabled()) return false;
 
         return true;
     },

--- a/sources/osgViewer/eventProxy/Hammer.js
+++ b/sources/osgViewer/eventProxy/Hammer.js
@@ -37,10 +37,15 @@ HammerController.prototype = {
     },
 
     isValid: function() {
-        if (this._enable && this.getManipulatorController()) {
-            return true;
-        }
-        return false;
+        if (!this._enable) return false;
+
+        var manipulator = this._viewer.getManipulator();
+        if (!manipulator) return false;
+
+        var controller = manipulator.getControllerList()[this._type];
+        if (!controller || !controller.isEnabled()) return false;
+
+        return true;
     },
 
     getManipulatorController: function() {

--- a/sources/osgViewer/eventProxy/StandardMouseKeyboard.js
+++ b/sources/osgViewer/eventProxy/StandardMouseKeyboard.js
@@ -1,4 +1,4 @@
-import { vec2 } from 'osg/glMatrix';
+import {vec2} from 'osg/glMatrix';
 
 var StandardMouseKeyboard = function(viewer) {
     this._enable = true;
@@ -88,15 +88,17 @@ StandardMouseKeyboard.prototype = {
     },
 
     isValid: function() {
-        if (
-            this._enable &&
-            this._viewer.getManipulator() &&
-            this._viewer.getManipulator().getControllerList()[this._type]
-        ) {
-            return true;
-        }
-        return false;
+        if (!this._enable) return false;
+
+        var manipulator = this._viewer.getManipulator();
+        if (!manipulator) return false;
+
+        var controller = manipulator.getControllerList()[this._type];
+        if (!controller || !controller.isEnabled()) return false;
+
+        return true;
     },
+
     getManipulatorController: function() {
         return this._viewer.getManipulator().getControllerList()[this._type];
     },

--- a/sources/osgViewer/eventProxy/WebVR.js
+++ b/sources/osgViewer/eventProxy/WebVR.js
@@ -57,7 +57,8 @@ WebVR.prototype = {
         var manipulator = this._viewer.getManipulator();
         if (!manipulator) return false;
 
-        if (!manipulator.getControllerList()[this._type]) return false;
+        var controller = manipulator.getControllerList()[this._type];
+        if (!controller || !controller.isEnabled()) return false;
 
         if (!this._hmd) return false;
 


### PR DESCRIPTION
Doing this improvement trigger some issues how events are handled in osgjs. The way events works in osgjs is through eventProxies.
eventProxies are responsible to initialize differents device and get events from them. Then we have different adapters to translate events from different device to manipulators.

On osgStats we need to pick a gl quads and scroll it if it hits. 
The problem is that manipulator is connected to StandardMouseKeyboard proxy and a mouseDown will also start to inititate a rotation on the orbit manipulator. Even if it's possible to disable the StandardMouseKeyboard proxy after the mouse down, we still have a side effect at the mouseup event because orbit manipulator has received the first mousedown. So to fix this we inject the mouseup in StandardMouseKeyboard at the end of the scroll to simulate we released the button (remember the proxy was disable).
To have osgStats working as we would like we would need to have eventProxies more general not only designed for manipulator, and we would need to have like some piority how events are consumed.
For example in this context I would like osgStats to consume events first and be able to discard them for others manipulators if needed

feedbacks ?
