### PR TITLE
Reduces shadow uniform size

### DIFF
--- a/examples/shadowmap/pcf.glsl
+++ b/examples/shadowmap/pcf.glsl
@@ -2,7 +2,7 @@
 
 float getShadowPCF(
     const in sampler2D depths,
-    const in vec4 size,
+    const in vec2 size,
     const in vec2 uv,
     const in float compare,
     const in vec2 biasPCF,
@@ -16,10 +16,10 @@ float getShadowPCF(
      if (pcf <= 1.0) return res;
 
 
-     float dx0 = -size.z;
-     float dy0 = -size.w;
-     float dx1 = size.z;
-     float dy1 = size.w;
+     float dx0 = -size.x;
+     float dy0 = -size.y;
+     float dx1 = size.x;
+     float dy1 = size.y;
 
 #define TSF(o1,o2) texture2DShadowLerp(depths, size, uv + vec2(o1, o2) + biasPCF, compare, clampDimension OPT_INSTANCE_ARG_outDistance OPT_INSTANCE_ARG_jitter)
 
@@ -40,10 +40,10 @@ float getShadowPCF(
 
     if (pcf <= 9.0) return res / 9.0;
 
-    float dx02 = -2.0*size.z;
-    float dy02 = -2.0*size.w;
-    float dx2 = 2.0*size.z;
-    float dy2 = 2.0*size.w;
+    float dx02 = 2.0*dx0
+    float dy02 = 2.0*dy0
+    float dx2 = 2.0*dx1;
+    float dy2 = 2.0*dy1;
 
     // complete row above
     res += TSF(dx0, dx02);

--- a/sources/osgShader/CompilerFragment.js
+++ b/sources/osgShader/CompilerFragment.js
@@ -345,10 +345,12 @@ var CompilerFragment = {
             vertexWorld: this.getOrCreateModelVertex(),
             shadowTexture: this.getOrCreateSampler('sampler2D', 'Texture' + tUnit),
             shadowSize: this.getOrCreateUniform(textureUniforms['RenderSize']),
-            shadowProjectionMatrix: this.getOrCreateUniform(
-                textureUniforms['ProjectionMatrix' + suffix]
-            ),
-            shadowViewMatrix: this.getOrCreateUniform(textureUniforms['ViewMatrix' + suffix]),
+            shadowProjection: this.getOrCreateUniform(textureUniforms['Projection' + suffix]),
+
+            shadowViewRight: this.getOrCreateUniform(textureUniforms['ViewRight' + suffix]),
+            shadowViewUp: this.getOrCreateUniform(textureUniforms['ViewUp' + suffix]),
+            shadowViewLook: this.getOrCreateUniform(textureUniforms['ViewLook' + suffix]),
+
             shadowDepthRange: this.getOrCreateUniform(textureUniforms['DepthRange' + suffix]),
             shadowBias: this.getOrCreateUniform(shadowUniforms.bias)
         };

--- a/sources/osgShadow/shaders/shadowCast.glsl
+++ b/sources/osgShadow/shaders/shadowCast.glsl
@@ -1,11 +1,11 @@
 #pragma include "colorEncode.glsl"
 
 #pragma DECLARE_FUNCTION
-vec4 shadowCast(const in vec4 fragEye, const in vec4 shadowDepthRange){
+vec4 shadowCast(const in vec4 fragEye, const in vec2 shadowDepthRange){
     // distance to camera (we make sure we are near 0 and in [0,1])
-    float depth = (-fragEye.z * fragEye.w - shadowDepthRange.x) * shadowDepthRange.w;
+    float depth = (-fragEye.z * fragEye.w - shadowDepthRange.x) / (shadowDepthRange.y - shadowDepthRange.x);
 
-#ifdef _FLOATTEX 
+#ifdef _FLOATTEX
     return vec4(depth, 0.0, 0.0, 1.0);
 #else
     return encodeFloatRGBA(depth);

--- a/sources/osgShadow/shaders/shadowLinearSoft.glsl
+++ b/sources/osgShadow/shaders/shadowLinearSoft.glsl
@@ -24,14 +24,14 @@ vec3 randJitter(const in vec3 p2) {
 // simulates linear fetch like texture2d shadow
 float texture2DShadowLerp(
     const in sampler2D depths,
-    const in vec4 size,
+    const in vec2 size,
     const in vec2 uv,
     const in float compare,
     const in vec4 clampDimension
     OPT_ARG_outDistance
     OPT_ARG_jitter){
 
-    vec2 centroidCoord = uv * size.xy;
+    vec2 centroidCoord = uv / size.xy;
 
 #ifdef _JITTER_OFFSET
     if (jitter > 0.0){
@@ -41,14 +41,14 @@ float texture2DShadowLerp(
 
     centroidCoord = centroidCoord + 0.5;
     vec2 f = fract(centroidCoord);
-    vec2 centroidUV = floor(centroidCoord) * size.zw;
+    vec2 centroidUV = floor(centroidCoord) * size.xy;
 
     vec4 fetches;
     const vec2 shift  = vec2(1.0, 0.0);
-    fetches.x = texture2DCompare(depths, centroidUV + size.zw * shift.yy, compare, clampDimension);
-    fetches.y = texture2DCompare(depths, centroidUV + size.zw * shift.yx, compare, clampDimension);
-    fetches.z = texture2DCompare(depths, centroidUV + size.zw * shift.xy, compare, clampDimension);
-    fetches.w = texture2DCompare(depths, centroidUV + size.zw * shift.xx, compare, clampDimension);
+    fetches.x = texture2DCompare(depths, centroidUV + size.xy * shift.yy, compare, clampDimension);
+    fetches.y = texture2DCompare(depths, centroidUV + size.xy * shift.yx, compare, clampDimension);
+    fetches.z = texture2DCompare(depths, centroidUV + size.xy * shift.xy, compare, clampDimension);
+    fetches.w = texture2DCompare(depths, centroidUV + size.xy * shift.xx, compare, clampDimension);
 
 
 

--- a/sources/osgShadow/shaders/tapPCF.glsl
+++ b/sources/osgShadow/shaders/tapPCF.glsl
@@ -2,7 +2,7 @@
 
 float getShadowPCF(
     const in sampler2D depths,
-    const in vec4 size,
+    const in vec2 size,
     const in vec2 uv,
     const in float compare,
     const in vec2 biasPCF,
@@ -19,10 +19,10 @@ float getShadowPCF(
 
 #else
 
-    float dx0 = -size.z;
-    float dy0 = -size.w;
-    float dx1 = size.z;
-    float dy1 = size.w;
+    float dx0 = -size.x;
+    float dy0 = -size.y;
+    float dx1 = size.x;
+    float dy1 = size.y;
 
 #define TSF(o1,o2) texture2DShadowLerp(depths, size, uv + vec2(o1, o2) + biasPCF, compare, clampDimension OPT_INSTANCE_ARG_outDistance OPT_INSTANCE_ARG_jitter)
 
@@ -47,10 +47,10 @@ float getShadowPCF(
 
 #elif defined(_PCFx25)
 
-    float dx02 = -2.0*size.z;
-    float dy02 = -2.0*size.w;
-    float dx2 = 2.0*size.z;
-    float dy2 = 2.0*size.w;
+    float dx02 = 2.0*dx0;
+    float dy02 = 2.0*dy0;
+    float dx2 = 2.0*dx1;
+    float dy2 = 2.0*dy1;
 
     // complete row above
     res += TSF(dx0, dx02);


### PR DESCRIPTION
For 4 shadows

- New Count       **24 uniforms.**
- Previous Count 42 Uniforms

( Removes At least 16 uniform vector, more depends on other uniforms)

Done:  
------
```
Uniform             | Before        | After
----------------------------------------------
- projection        | Mat4          |  Vec3
- view              | Mat4          | 3 Vec4
- depth range       | Vec4          |  Vec2
- shadow size       | Vec4          |  Vec2

```

IF we go Manual Packing: 25 Vector
---------
```
Uniform                | Before     | After
----------------------------------------------
- projection, bias    | vec3, float | Vec4
- range, mapSize      | vec2, vec2  | Vec4
- float jitter float  | 4 float     | vec4 
```


Side Benefit: 40 mul optimized out 
(derivated out the 0/1 and unused computation in all view/projection vec4 mul/dot)