### PR TITLE
Restores the behaviour of First Person Manipulator.

### DIFF
--- a/sources/osgGA/FirstPersonManipulatorStandardMouseKeyboardController.js
+++ b/sources/osgGA/FirstPersonManipulatorStandardMouseKeyboardController.js
@@ -10,16 +10,15 @@ utils.createPrototypeObject(
     FirstPersonManipulatorStandardMouseKeyboardController,
     utils.objectInherit(Controller.prototype, {
         init: function() {
-            this.releaseButton();
             this._delay = 0.15;
             this._stepFactor = 1.0; // meaning radius*stepFactor to move
-            this._buttonup = false;
+            this._buttonup = true;
         },
         // called to enable/disable controller
         setEnable: function(bool) {
             if (!bool) {
                 // reset mode if we disable it
-                this._buttonup = false;
+                this._buttonup = true;
             }
             Controller.prototype.setEnable.call(this, bool);
         },


### PR DESCRIPTION
It was changed when the line `this._buttonup = false;` was added. Before that, this._buttonup was set to true in the call to `this.releaseButton()`. Have you changed this intentionally?