### PR TITLE
Adds a method to RenderBin and RenderStage to clean their PooledResource objects

### DIFF
--- a/sources/osg/RenderBin.js
+++ b/sources/osg/RenderBin.js
@@ -328,4 +328,8 @@ RenderBin.reset = function() {
     pooledRenderBin.reset();
 };
 
+RenderBin.clean = function () {
+    pooledRenderBin.clean();
+};
+
 export default RenderBin;

--- a/sources/osg/RenderStage.js
+++ b/sources/osg/RenderStage.js
@@ -313,4 +313,8 @@ utils.createPrototypeObject(
     'RenderStage'
 );
 
+RenderStage.clean = function () {
+    pooledRenderStageOrder.clean();
+};
+
 export default RenderStage;

--- a/sources/osgViewer/Viewer.js
+++ b/sources/osgViewer/Viewer.js
@@ -28,6 +28,9 @@ import InputSourceWebVR from 'osgViewer/input/source/InputSourceWebVR';
 import InputSourceGamePad from 'osgViewer/input/source/InputSourceGamePad';
 import InputSourceDeviceOrientation from 'osgViewer/input/source/InputSourceDeviceOrientation';
 import InputSourceTouchScreen from 'osgViewer/input/source/InputSourceTouchScreen';
+import RenderBin from 'osg/RenderBin';
+import RenderStage from 'osg/RenderStage';
+import StateGraph from 'osg/StateGraph';
 
 var Viewer = function(canvas, userOptions, error) {
     View.call(this);
@@ -571,6 +574,12 @@ utils.createPrototypeObject(
         setEnableManipulator: function(bool) {
             if (!this._manipulator) return;
             this._manipulator.setEnable(bool);
+        },
+
+        dispose: function () {
+            RenderBin.clean();
+            RenderStage.clean();
+            StateGraph.pooledStateGraph.clean();
         }
     }),
     'osgViewer',


### PR DESCRIPTION
When the canvas is removed the PooledResource objects in RenderBin and RenderStage are not cleaned and they keep references to BufferArrays so the memory is not freed. 

Adding this two methods allows to free that memory.