### PR TITLE
Removes unecessary camera delete/recreation

### DIFF
--- a/sources/osgShadow/ShadowMap.js
+++ b/sources/osgShadow/ShadowMap.js
@@ -340,14 +340,6 @@ utils.createPrototypeObject(
 
             this.checkLightNumber();
 
-            if (!this._cameraShadow) {
-                this._cameraShadow = new Camera();
-                this._cameraShadow.setCullCallback(new CameraCullCallback(this));
-                this._cameraShadow.setRenderOrder(Camera.PRE_RENDER, 0);
-                this._cameraShadow.setReferenceFrame(Transform.ABSOLUTE_RF);
-                this._cameraShadow.setClearColor(vec4.fromValues(1.0, 1.0, 1.0, 1.0));
-            }
-
             var lightNumber = this._light.getLightNumber();
 
             if (!atlasTexture) {
@@ -975,11 +967,8 @@ utils.createPrototypeObject(
         },
         cleanSceneGraph: function(ignoreTexture) {
             // well release a lot more things when it works
-            this._cameraShadow = undefined;
             this._needRedraw = true;
-
             this.cleanReceivingStateSet(ignoreTexture);
-
             // TODO: need state
             //this._texture.releaseGLObjects();
             //this._shadowReceiveAttribute = undefined;


### PR DESCRIPTION
user code could have wrong camera reference. 
It fixes "stats" that could be non existant on camera shadow, as they were done on "camera.setinitalDrawCallback". As camera could be deleted/renewed, that callback wouldn't be called.