### PR TITLE
Fixes shader error handling when spector enabled

### DIFF
--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -346,8 +346,6 @@ utils.createPrototypeStateAttribute(
                     }
                 }
 
-                this._bindProgramToSpector();
-
                 this._uniformsCache = {};
                 this._attributesCache = {};
 
@@ -359,6 +357,7 @@ utils.createPrototypeStateAttribute(
                     this.cacheAttributeList(gl, window.Object.keys(this._attributeMap));
                     this.cacheUniformList(gl, window.Object.keys(this._uniformMap));
                 }
+                this._bindProgramToSpector();
                 return compileClean;
             },
 


### PR DESCRIPTION
With spectorJS enabled, it was segfaulting when we got "error in
shader" instead of going to failsafe  because we tried to access it
before we compiled the failsafe.