### PR TITLE
Fixes context restoring not able to compile program again

### DIFF
--- a/sources/osg/Program.js
+++ b/sources/osg/Program.js
@@ -233,6 +233,7 @@ utils.createPrototypeStateAttribute(
                 this._foreignUniforms = undefined;
                 this._trackAttributes = undefined;
 
+                this._compileClean = undefined;
                 this._program = undefined;
             },
 


### PR DESCRIPTION
Since decoupling program compilation/linking state, the context
restore didn't work