### PR TITLE
Fixes the missing emissive texture during GLTF file reading.

### DIFF
--- a/sources/osgPlugins/ReaderWriterGLTF.js
+++ b/sources/osgPlugins/ReaderWriterGLTF.js
@@ -739,7 +739,8 @@ ReaderWriterGLTF.prototype = {
                     ReaderWriterGLTF.EMISSIVE_TEXTURE_UNIT,
                     osgjsTexture
                 );
-            } else if (material.emissiveFactor) {
+            }
+            if (material.emissiveFactor) {
                 stateSet.addUniform(
                     Uniform.createFloat3(material.emissiveFactor, 'uEmissiveFactor')
                 );


### PR DESCRIPTION
Before my fix, ReaderWriterGLTF only read either *emissiveTexture* or *emissiveFactor*.
This bug made the emissive texture not appear on PBR models.
Now, ReaderWriterGLTF reads both variables.