### PR TITLE
Removal of the json-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "grunt-webpack": "^3.0.2",
     "hammerjs": "^2.0.8",
     "jquery": "3.0.0",
-    "json-loader": "^0.5.4",
     "path": "^0.11.14",
     "raw-loader": "^0.5.1",
     "webpack": "^3.7.1",

--- a/sources/osgNameSpace.js
+++ b/sources/osgNameSpace.js
@@ -1,4 +1,4 @@
-import pkg from 'json-loader!../package.json';
+import pkg from '../package.json';
 
 export default {
     name: pkg.name,


### PR DESCRIPTION
I propose the removal of the json-loader dependency. It is unmaintained, and the Webpack version used by osgjs includes natively a json loader.

In my use-case, it would helps a lot: I import OSG modules directly from source (as opposed to loading the whole distribution) to make use of the tree-shaking ability of Webpack. But the explicit use of the json-loader in "osgNameSpace.js" conflicts with the default Webpack 3/4 behavior. It forces the installation an unmaintained package and to make a special case in webpack.config.js for osgjs.
