### PR TITLE
Fix zip loading

### DIFF
--- a/sources/osgPlugins/ReaderWriterZIP.js
+++ b/sources/osgPlugins/ReaderWriterZIP.js
@@ -64,9 +64,7 @@ ReaderWriterZIP.prototype = {
                         break;
                     }
                 }
-
                 this._filesMap = filesMap;
-
             }.bind(this)
         );
     }


### PR DESCRIPTION

[test-zip-loading.zip](https://github.com/cedricpinson/osgjs/files/2718392/test-zip-loading.zip)
This patch resolve some problems I encountered while trying to load zip files from a server :
- Missing return statement that were preventing promise to works when zip file where loaded from a server. 
- After loading a Zip file, the fileMap was not updated. osgDB would then try to load files that were in the zip directly from the server.
- Since the fileMap is a real Map object, the [] operator wouldn't work to check if file were existing.

Here is the error I would get when loading a zip file without the return  statements :

```
Unhandled rejection readNodeURL/<@webpack:///./sources/osgPlugins/ReaderWriterZIP.js?:49:13
r@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:31:9667
[22]</e.exports/i.prototype._settlePromiseFromHandler@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:14825
[22]</e.exports/i.prototype._settlePromise@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:15628
[22]</e.exports/i.prototype._settlePromise0@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:16329
[22]</e.exports/i.prototype._settlePromises@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:17684
c@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:1555
a@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:1496
[2]</r.prototype._drainQueues@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:3106
r/this.drainQueues@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:1236
```

Here is a test case to be used in the examples folder :
[test-zip-loading.zip](https://github.com/cedricpinson/osgjs/files/2718395/test-zip-loading.zip)
