### PR TITLE
Fix gltf loading

### DIFF
--- a/sources/osgPlugins/ReaderWriterGLTF.js
+++ b/sources/osgPlugins/ReaderWriterGLTF.js
@@ -964,6 +964,9 @@ ReaderWriterGLTF.prototype = {
         this._localPath = index === -1 ? '' : url.substr(0, index + 1);
         // Else it is a usual XHR request
         return fileHelper.requestURI(url).then(function(file) {
+            if(typeof file === 'string'){
+              file = JSON.parse(file);
+            }
             return self.readJSON(file);
         });
     },

--- a/sources/osgPlugins/ReaderWriterGLTF.js
+++ b/sources/osgPlugins/ReaderWriterGLTF.js
@@ -964,8 +964,8 @@ ReaderWriterGLTF.prototype = {
         this._localPath = index === -1 ? '' : url.substr(0, index + 1);
         // Else it is a usual XHR request
         return fileHelper.requestURI(url).then(function(file) {
-            if(typeof file === 'string'){
-              file = JSON.parse(file);
+            if (typeof file === 'string') {
+                file = JSON.parse(file);
             }
             return self.readJSON(file);
         });

--- a/sources/osgPlugins/ReaderWriterGLTF.js
+++ b/sources/osgPlugins/ReaderWriterGLTF.js
@@ -945,7 +945,7 @@ ReaderWriterGLTF.prototype = {
 
         var result = this._filesMap[uri];
         if (result !== undefined) return result;
-        return fileHelper.requestURI(uri, options);
+        return fileHelper.requestResource(uri, options);
     }),
 
     readNodeURL: function(url, options) {


### PR DESCRIPTION
When a glTF file is loaded directly from a server, outside any zip/gz archive, it is treated as text file instead of being parsed correctly as a JSON. Images are sometimes also not loaded correctly when loaded from loadImages() because fileloader.requestURI() would confuse it for a type 'arraybuffer'.

The error I get with gltf : 
`Unhandled rejection ReaderWriterGLTF.prototype.loadBuffers<@webpack:///./sources/osgPlugins/ReaderWriterGLTF.js?:251:25
r@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:31:9667
[19]</e.exports/e.method/<@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:4044
ReaderWriterGLTF.prototype.readJSON<@webpack:///./sources/osgPlugins/ReaderWriterGLTF.js?:1007:70
r@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:31:9667
[19]</e.exports/e.method/<@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:4044
readNodeURL/<@webpack:///./sources/osgPlugins/ReaderWriterGLTF.js?:1000:20
r@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:31:9667
[22]</e.exports/i.prototype._settlePromiseFromHandler@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:14825
[22]</e.exports/i.prototype._settlePromise@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:15628
[22]</e.exports/i.prototype._settlePromise0@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:16329
[22]</e.exports/i.prototype._settlePromises@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:30:17684
c@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:1555
a@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:1496
[2]</r.prototype._drainQueues@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:3106
r/this.drainQueues@http://localhost:9000/node_modules/bluebird/js/browser/bluebird.min.js:29:1236`

The test case, to put in the "examples" folder 
[test-gltf-loading.zip](https://github.com/cedricpinson/osgjs/files/2718424/test-gltf-loading.zip)
